### PR TITLE
Eliminate status dice flash when roll starts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ const BOTTOM_LEFT = [11, 10, 9, 8, 7, 6];
 const BOTTOM_RIGHT = [5, 4, 3, 2, 1, 0];
 const MOVE_STEP_MS = 210;
 const MOVE_START_DELAY_MS = 40;
+const BOARD_DICE_ROLL_MS = 1000;
 
 function wait(ms) {
   return new Promise((resolve) => {
@@ -81,7 +82,7 @@ function describeRequiredAction(state, legalMoves) {
   return state.statusText;
 }
 
-function DieFace({ value, animateKey, className = '', ariaHidden = false, used = false }) {
+function DieFace({ value, className = '', ariaHidden = false, used = false }) {
   const safeValue = Math.min(6, Math.max(1, Number(value) || 1));
   const pipsByValue = {
     1: [5],
@@ -94,7 +95,6 @@ function DieFace({ value, animateKey, className = '', ariaHidden = false, used =
 
   return (
     <div
-      key={`${safeValue}-${animateKey}`}
       className={`die ${used ? 'die-used' : ''} ${className}`.trim()}
       role={ariaHidden ? undefined : 'img'}
       aria-label={ariaHidden ? undefined : `Die showing ${safeValue}${used ? ', used' : ''}`}
@@ -109,7 +109,11 @@ function DieFace({ value, animateKey, className = '', ariaHidden = false, used =
   );
 }
 
-function DicePanel({ game, diceAnimKey }) {
+function DicePanel({ game, isBoardDiceRolling }) {
+  if (isBoardDiceRolling || game.dice.values.length !== 2) {
+    return <div className="dice-panel" aria-label="Dice" />;
+  }
+
   const remainingCounts = {};
   for (const die of game.dice.remaining) {
     remainingCounts[die] = (remainingCounts[die] ?? 0) + 1;
@@ -131,18 +135,9 @@ function DicePanel({ game, diceAnimKey }) {
 
   return (
     <div className="dice-panel" aria-label="Dice">
-      {game.dice.values.length === 2 ? (
-        <>
-          {rolledDiceWithUsage.map((die, i) => (
-            <DieFace key={`status-die-${i}`} value={die.value} used={die.used} animateKey={diceAnimKey + i} />
-          ))}
-        </>
-      ) : (
-        <>
-          <div className="die die-empty" />
-          <div className="die die-empty" />
-        </>
-      )}
+      {rolledDiceWithUsage.map((die, i) => (
+        <DieFace key={`status-die-${i}`} value={die.value} used={die.used} />
+      ))}
     </div>
   );
 }
@@ -298,12 +293,14 @@ export default function App() {
   const [game, setGame] = useState(loadInitial);
   const [selectedSource, setSelectedSource] = useState(null);
   const [diceAnimKey, setDiceAnimKey] = useState(0);
+  const [isBoardDiceRolling, setIsBoardDiceRolling] = useState(false);
   const [isAnimatingMove, setIsAnimatingMove] = useState(false);
   const [movingChecker, setMovingChecker] = useState(null);
   const boardStageRef = useRef(null);
   const pointRefs = useRef(new Map());
   const barRef = useRef(null);
   const bearOffRefs = useRef({ A: null, B: null });
+  const boardDiceRollTimerRef = useRef(null);
   const isComputerTurn = game.currentPlayer === PLAYER_B;
 
   const legalMoves = useMemo(() => computeLegalMoves(game), [game]);
@@ -382,10 +379,32 @@ export default function App() {
 
   const diceSignature = game.dice.values.join('-');
   useEffect(() => {
-    if (game.dice.values.length === 2) {
-      setDiceAnimKey((k) => k + 2);
+    if (boardDiceRollTimerRef.current) {
+      window.clearTimeout(boardDiceRollTimerRef.current);
+      boardDiceRollTimerRef.current = null;
     }
+
+    if (game.dice.values.length === 2) {
+      setIsBoardDiceRolling(true);
+      setDiceAnimKey((k) => k + 2);
+      boardDiceRollTimerRef.current = window.setTimeout(() => {
+        setIsBoardDiceRolling(false);
+        boardDiceRollTimerRef.current = null;
+      }, BOARD_DICE_ROLL_MS);
+      return undefined;
+    }
+
+    setIsBoardDiceRolling(false);
+    return undefined;
   }, [diceSignature]);
+
+  useEffect(() => {
+    return () => {
+      if (boardDiceRollTimerRef.current) {
+        window.clearTimeout(boardDiceRollTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (game.winner || !isComputerTurn) {
@@ -401,6 +420,7 @@ export default function App() {
           if (prev.winner || prev.currentPlayer !== PLAYER_B || prev.dice.remaining.length > 0) {
             return prev;
           }
+          startBoardDiceRollVisibilityWindow();
           return pushUndoState(prev, rollDice(prev));
         });
         return;
@@ -429,6 +449,17 @@ export default function App() {
     return pushUndoState(game, nextState);
   }
 
+  function startBoardDiceRollVisibilityWindow() {
+    if (boardDiceRollTimerRef.current) {
+      window.clearTimeout(boardDiceRollTimerRef.current);
+    }
+    setIsBoardDiceRolling(true);
+    boardDiceRollTimerRef.current = window.setTimeout(() => {
+      setIsBoardDiceRolling(false);
+      boardDiceRollTimerRef.current = null;
+    }, BOARD_DICE_ROLL_MS);
+  }
+
   function handleRoll(forced = null) {
     if (isAnimatingMove || (isComputerTurn && !forced)) {
       return;
@@ -437,6 +468,7 @@ export default function App() {
     if (rolled === game) {
       return;
     }
+    startBoardDiceRollVisibilityWindow();
     commit(withUndo(rolled));
     setSelectedSource(null);
   }
@@ -710,7 +742,7 @@ export default function App() {
       <section className="status" aria-live="polite">
         <div><strong>Turn:</strong> {isComputerTurn ? 'Computer' : 'Player'}</div>
         <div><strong>Action:</strong> {statusText}</div>
-        <DicePanel game={game} diceAnimKey={diceAnimKey} />
+        <DicePanel game={game} isBoardDiceRolling={isBoardDiceRolling} />
       </section>
 
       <section className="controls" aria-label="Game controls">

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,7 +115,6 @@ button:focus-visible {
   overflow: hidden;
   display: grid;
   place-items: center;
-  animation: dieRoll 1s ease-out;
 }
 
 .die-used {


### PR DESCRIPTION
### Motivation
- Prevent a very brief one-frame flash of the status-area dice that appears immediately when a user clicks `Roll Dice` by hiding the status dice as soon as a roll begins.

### Description
- Added `BOARD_DICE_ROLL_MS` and a new `isBoardDiceRolling` state plus `boardDiceRollTimerRef` to `src/App.jsx` to gate status-area dice visibility during board dice animation.
- Introduced `startBoardDiceRollVisibilityWindow()` helper and invoke it immediately in `handleRoll()` and the computer auto-roll path so the status dice are hidden in the same interaction cycle as the roll start.
- Updated `DicePanel` to accept `isBoardDiceRolling` and return an empty dice panel while the board roll window is active, and removed the one-frame `animateKey` usage that could reveal a transient die.
- Added timer cleanup in an unmount effect to avoid stale timeouts and kept the existing dice-signature effect to manage board dice visibility for non-immediate roll paths.

### Testing
- Ran `npm run build` and the build completed successfully.
- Started the dev server and ran a Playwright script that clicked `Roll Dice` and captured a ~10ms post-click screenshot which confirmed the status-area dice no longer flash; the script succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c4274cf5c832e8e89859386451399)