### PR TITLE
Delay AI checker movement until dice roll animation completes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -410,7 +410,7 @@ export default function App() {
     if (game.winner || !isComputerTurn) {
       return undefined;
     }
-    if (isAnimatingMove) {
+    if (isAnimatingMove || isBoardDiceRolling) {
       return undefined;
     }
 
@@ -439,7 +439,7 @@ export default function App() {
     }, 420);
 
     return () => window.clearTimeout(timer);
-  }, [game, isComputerTurn, isAnimatingMove]);
+  }, [game, isComputerTurn, isAnimatingMove, isBoardDiceRolling]);
 
   function commit(next) {
     setGame(next);


### PR DESCRIPTION
### Motivation
- Prevent the computer player from starting to move checkers while the board dice roll animation is still visible so moves only start after the roll finishes.

### Description
- Short-circuited the computer-turn effect when `isBoardDiceRolling` is true by updating the conditional in `src/App.jsx` to check `isAnimatingMove || isBoardDiceRolling`.
- Added `isBoardDiceRolling` to the effect dependency list so the AI scheduling effect re-runs only after the roll animation window clears.

### Testing
- Ran `npm run build` which completed successfully.
- Launched the dev server and captured an automated Playwright screenshot of the running app to validate the dice roll visibility behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5b4e24dc832eb4381798ff8492f5)