### PR TITLE
Highlight movable checkers after each dice roll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -207,7 +207,7 @@ function BoardDice({ game, diceAnimKey }) {
   );
 }
 
-function Point({ index, value, selected, highlighted, onClick, isTop, pointRef }) {
+function Point({ index, value, selected, highlighted, movable, onClick, isTop, pointRef }) {
   const owner = pointOwner(value);
   const count = checkerCount(value);
   const stackDivisor = Math.max(4, count - 1);
@@ -215,7 +215,7 @@ function Point({ index, value, selected, highlighted, onClick, isTop, pointRef }
   return (
     <button
       ref={pointRef}
-      className={`point ${isTop ? 'point-top' : 'point-bottom'} ${selected ? 'selected is-selected' : ''} ${highlighted ? 'legal is-legal' : ''}`}
+      className={`point ${isTop ? 'point-top' : 'point-bottom'} ${selected ? 'selected is-selected' : ''} ${highlighted ? 'legal is-legal' : ''} ${movable ? 'movable-source' : ''}`}
       onClick={onClick}
       aria-label={`Point ${index + 1}`}
       type="button"
@@ -224,7 +224,7 @@ function Point({ index, value, selected, highlighted, onClick, isTop, pointRef }
         {Array.from({ length: count }).map((_, i) => (
           <span
             key={i}
-            className={`checker stack-checker checker-${owner === 'B' ? 'b' : 'a'}`}
+            className={`checker stack-checker checker-${owner === 'B' ? 'b' : 'a'} ${movable && i === count - 1 ? 'checker-movable' : ''}`}
             style={{
               '--stack-index': i,
               '--stack-offset': i / stackDivisor,
@@ -237,7 +237,7 @@ function Point({ index, value, selected, highlighted, onClick, isTop, pointRef }
   );
 }
 
-function Bar({ state, selected, highlighted, onClick, barRef }) {
+function Bar({ state, selected, highlighted, movable, onClick, barRef }) {
   const aCount = state.bar.A;
   const bCount = state.bar.B;
   const visibleA = Math.min(aCount, 5);
@@ -246,7 +246,7 @@ function Bar({ state, selected, highlighted, onClick, barRef }) {
   return (
     <button
       ref={barRef}
-      className={`bar-column ${selected ? 'selected is-selected' : ''} ${highlighted ? 'legal is-legal' : ''}`}
+      className={`bar-column ${selected ? 'selected is-selected' : ''} ${highlighted ? 'legal is-legal' : ''} ${movable ? 'movable-source' : ''}`}
       onClick={onClick}
       type="button"
       aria-label="Bar"
@@ -362,6 +362,16 @@ export default function App() {
     }
     return set;
   }, [moveOptionsForSelected]);
+
+  const movableSourceSet = useMemo(() => {
+    const set = new Set();
+    for (const move of legalMoves) {
+      set.add(sourceKey(move.from));
+    }
+    return set;
+  }, [legalMoves]);
+
+  const showMovableSources = !isAnimatingMove && !isComputerTurn && !game.winner && game.dice.remaining.length > 0;
 
   useEffect(() => {
     window.localStorage.setItem(STORAGE_KEY, serializeState(game));
@@ -718,6 +728,7 @@ export default function App() {
         }}
         selected={selectedSource === point}
         highlighted={destinationSet.has(String(point))}
+        movable={showMovableSources && movableSourceSet.has(String(point))}
         onClick={() => {
           if (isAnimatingMove || isComputerTurn) {
             return;
@@ -766,6 +777,7 @@ export default function App() {
               state={game}
               selected={selectedSource === 'bar'}
               highlighted={destinationSet.has('bar')}
+              movable={showMovableSources && movableSourceSet.has('bar')}
               onClick={() => {
                 if (isAnimatingMove || isComputerTurn) {
                   return;

--- a/src/styles.css
+++ b/src/styles.css
@@ -515,6 +515,15 @@ button:focus-visible {
   bottom: calc(var(--stack-offset) * (100% - var(--checker-size)));
 }
 
+.checker-movable {
+  box-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.35),
+    inset 0 2px 4px rgba(255, 255, 255, 0.35),
+    inset 0 -2px 4px rgba(0, 0, 0, 0.2),
+    0 0 0 2px rgba(255, 209, 102, 0.88),
+    0 0 12px 3px rgba(255, 209, 102, 0.68);
+}
+
 .moving-checker {
   position: absolute;
   z-index: 25;


### PR DESCRIPTION
### Motivation
- Make it obvious which checkers the human player can move immediately after rolling the dice by visually highlighting source points and the front checker in each movable stack. 

### Description
- Compute a `movableSourceSet` from `legalMoves` and only show movable indicators when it's the human's turn, dice remain, the game isn't over, and no move animation is running.  
- Add a `movable` prop to `Point` and `Bar` components and apply a `movable-source` class to the source element and a `checker-movable` class to the front-most checker in a movable stack.  
- Add CSS for `.checker-movable` to produce the yellow glow / outline effect matching the requested UI cue.  
- Wire `bar` as a source so entering from the bar is highlighted when legal.

### Testing
- Ran a production build with `npm run build` which completed successfully.  
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and manually verified the UI behavior after rolling dice.  
- Automated browser check using Playwright that rolled the dice and captured a screenshot showing movable checkers highlighted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7b7427b4832ea6da8f60c5f72f93)