### PR TITLE
Disable initial dice auto-roll and block interactions during roll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -301,6 +301,7 @@ export default function App() {
   const barRef = useRef(null);
   const bearOffRefs = useRef({ A: null, B: null });
   const boardDiceRollTimerRef = useRef(null);
+  const hasInitializedDiceAnimationRef = useRef(false);
   const isComputerTurn = game.currentPlayer === PLAYER_B;
 
   const legalMoves = useMemo(() => computeLegalMoves(game), [game]);
@@ -356,12 +357,15 @@ export default function App() {
   }, [game, movesBySource, selectedSource]);
 
   const destinationSet = useMemo(() => {
+    if (isBoardDiceRolling) {
+      return new Set();
+    }
     const set = new Set();
     for (const option of moveOptionsForSelected) {
       set.add(destinationKey(option.to));
     }
     return set;
-  }, [moveOptionsForSelected]);
+  }, [isBoardDiceRolling, moveOptionsForSelected]);
 
   const movableSourceSet = useMemo(() => {
     const set = new Set();
@@ -371,7 +375,7 @@ export default function App() {
     return set;
   }, [legalMoves]);
 
-  const showMovableSources = !isAnimatingMove && !isComputerTurn && !game.winner && game.dice.remaining.length > 0;
+  const showMovableSources = !isBoardDiceRolling && !isAnimatingMove && !isComputerTurn && !game.winner && game.dice.remaining.length > 0;
 
   useEffect(() => {
     window.localStorage.setItem(STORAGE_KEY, serializeState(game));
@@ -389,6 +393,12 @@ export default function App() {
 
   const diceSignature = game.dice.values.join('-');
   useEffect(() => {
+    if (!hasInitializedDiceAnimationRef.current) {
+      hasInitializedDiceAnimationRef.current = true;
+      setIsBoardDiceRolling(false);
+      return undefined;
+    }
+
     if (boardDiceRollTimerRef.current) {
       window.clearTimeout(boardDiceRollTimerRef.current);
       boardDiceRollTimerRef.current = null;
@@ -484,7 +494,7 @@ export default function App() {
   }
 
   function handleSelectSource(source) {
-    if (isAnimatingMove || isComputerTurn || game.winner || game.dice.remaining.length === 0) {
+    if (isBoardDiceRolling || isAnimatingMove || isComputerTurn || game.winner || game.dice.remaining.length === 0) {
       return;
     }
 
@@ -638,7 +648,7 @@ export default function App() {
   }
 
   function moveToDestination(destination) {
-    if (isAnimatingMove || isComputerTurn || selectedSource == null) {
+    if (isBoardDiceRolling || isAnimatingMove || isComputerTurn || selectedSource == null) {
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent the board from appearing to auto-roll dice when the site loads (e.g. restoring a saved game on mobile) and stop checkers from being highlighted or selectable while dice are still animating.

### Description
- Add `hasInitializedDiceAnimationRef` and a first-run guard to skip the board-dice roll animation on initial render so restored dice values do not trigger the roll animation.
- Suppress destination highlights by returning an empty `destinationSet` while `isBoardDiceRolling` and include `isBoardDiceRolling` in the memo deps.
- Prevent movable-source highlighting by gating `showMovableSources` on `!isBoardDiceRolling`.
- Block source selection and move execution while `isBoardDiceRolling` by adding checks to `handleSelectSource` and `moveToDestination`.

### Testing
- Ran `npm run build` and the build completed successfully.
- Started the dev server and executed an automated Playwright script that loaded the app at a mobile viewport and captured a screenshot to validate the initial state; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c84870af0832ebb13c0fb77955d99)