### PR TITLE
Fix stretched checker shape on mobile bar

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -436,6 +436,9 @@ button:focus-visible {
   background: transparent;
   padding: 0;
   border-radius: 50%;
+  min-height: 0;
+  width: var(--checker-size);
+  height: var(--checker-size);
 }
 
 .barCheckerInteractive {


### PR DESCRIPTION
### Motivation
- On small viewports the interactive bar checker button inherited the global `button` minimum height and became vertically stretched, breaking the intended circular checker appearance.

### Description
- Constrain the interactive bar-checker control by updating `.bar-checker-button` to `min-height: 0` and set explicit `width` and `height` to `var(--checker-size)` so the checker remains circular.

### Testing
- Built the production bundle with `npm run build` (succeeded) and ran a headless Playwright script that loaded a mobile viewport and captured a screenshot verifying the bar checker renders with the correct aspect ratio (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd7dc2854832eaea4e0c6a205787b)