### PR TITLE
Modernize UI: board-first mobile HUD, on-board dice overlay, and menu sheet

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -140,27 +140,59 @@ function DieFace({ value, className = '', ariaHidden = false, used = false }) {
   );
 }
 
-function DicePanel({ game, isBoardDiceRolling, openingRollDisplay }) {
-  if (game.openingRollPending) {
-    return (
-      <div className="dice-panel" aria-label="Dice">
-        {openingRollDisplay?.playerDie ? <DieFace value={openingRollDisplay.playerDie} /> : null}
-        {openingRollDisplay?.computerDie ? <DieFace value={openingRollDisplay.computerDie} /> : null}
-      </div>
-    );
-  }
+function StatusChip({ text }) {
+  return (
+    <div className="status-chip" role="status" aria-live="polite">
+      {text}
+    </div>
+  );
+}
 
-  if (isBoardDiceRolling || game.dice.values.length !== 2) {
-    return <div className="dice-panel" aria-label="Dice" />;
+function MenuSheet({ open, onClose, children }) {
+  if (!open) {
+    return null;
   }
-
-  const rolledDiceWithUsage = getRolledDiceWithUsage(game);
 
   return (
-    <div className="dice-panel" aria-label="Dice">
-      {rolledDiceWithUsage.map((die, i) => (
-        <DieFace key={`status-die-${i}`} value={die.value} used={die.used} />
-      ))}
+    <div className="menu-sheet-backdrop" onClick={onClose} role="presentation">
+      <section className="menu-sheet" onClick={(event) => event.stopPropagation()} aria-label="Game menu">
+        <div className="menu-sheet-handle" aria-hidden="true" />
+        <header className="menu-sheet-header">
+          <h2>Game Menu</h2>
+          <button type="button" className="icon-btn" onClick={onClose} aria-label="Close menu">✕</button>
+        </header>
+        {children}
+      </section>
+    </div>
+  );
+}
+
+function BoardHUD({ game, diceAnimKey, isBoardDiceRolling, openingRollDisplay, canRoll, onRoll }) {
+  const rolledDiceWithUsage = getRolledDiceWithUsage(game, {
+    expandDoubles: !isBoardDiceRolling
+  });
+
+  if (!game.openingRollPending && !rolledDiceWithUsage.length && !canRoll) {
+    return null;
+  }
+
+  return (
+    <div className="board-hud-overlay" aria-live="polite">
+      {canRoll && (
+        <button type="button" className="roll-cta" onClick={onRoll} aria-label="Roll dice">
+          Roll
+        </button>
+      )}
+      {game.openingRollPending && (
+        <div className="dice-state-card" aria-label="Opening roll dice">
+          <span className="dice-state-title">Opening roll</span>
+          <div className="dice-panel">
+            {openingRollDisplay?.playerDie ? <DieFace value={openingRollDisplay.playerDie} /> : null}
+            {openingRollDisplay?.computerDie ? <DieFace value={openingRollDisplay.computerDie} /> : null}
+          </div>
+        </div>
+      )}
+      <BoardDice game={game} diceAnimKey={diceAnimKey} isBoardDiceRolling={isBoardDiceRolling} />
     </div>
   );
 }
@@ -175,10 +207,13 @@ function BoardDice({ game, diceAnimKey, isBoardDiceRolling }) {
 
   if (!isBoardDiceRolling) {
     return (
-      <div className="board-dice-overlay" aria-hidden="true">
-        {rolledDiceWithUsage.map((die, idx) => (
-          <DieFace key={`board-static-die-${idx}-${die.value}`} value={die.value} used={die.used} ariaHidden />
-        ))}
+      <div className="dice-state-card" aria-label="Current dice and remaining moves">
+        <span className="dice-state-title">Moves left: {game.dice.remaining.length}</span>
+        <div className="board-dice-overlay" aria-hidden="true">
+          {rolledDiceWithUsage.map((die, idx) => (
+            <DieFace key={`board-static-die-${idx}-${die.value}`} value={die.value} used={die.used} ariaHidden />
+          ))}
+        </div>
       </div>
     );
   }
@@ -215,31 +250,34 @@ function BoardDice({ game, diceAnimKey, isBoardDiceRolling }) {
   }
 
   return (
-    <div className="board-dice-overlay" aria-hidden="true">
-      {rolledDiceWithUsage.map((die, idx) => {
-        const dieValue = die.value;
-        const finalValue = Math.min(6, Math.max(1, Number(dieValue) || 1));
-        const finalOrientation = orientationByValue[finalValue];
-        return (
-          <div key={`board-die-wrap-${idx}`} className={`board-die-perspective ${die.used ? 'board-die-used' : ''}`.trim()}>
-            <div
-              key={`board-die-${idx}-${finalValue}-${diceAnimKey + 2000 + idx}`}
-              className="board-die-cube"
-              style={{
-                '--end-rot-x': finalOrientation.x,
-                '--end-rot-y': finalOrientation.y
-              }}
-            >
-              {renderFace(1, 'board-die-front')}
-              {renderFace(6, 'board-die-back')}
-              {renderFace(3, 'board-die-right')}
-              {renderFace(4, 'board-die-left')}
-              {renderFace(5, 'board-die-top')}
-              {renderFace(2, 'board-die-bottom')}
+    <div className="dice-state-card" aria-label="Current dice and remaining moves">
+      <span className="dice-state-title">Moves left: {game.dice.remaining.length}</span>
+      <div className="board-dice-overlay" aria-hidden="true">
+        {rolledDiceWithUsage.map((die, idx) => {
+          const dieValue = die.value;
+          const finalValue = Math.min(6, Math.max(1, Number(dieValue) || 1));
+          const finalOrientation = orientationByValue[finalValue];
+          return (
+            <div key={`board-die-wrap-${idx}`} className={`board-die-perspective ${die.used ? 'board-die-used' : ''}`.trim()}>
+              <div
+                key={`board-die-${idx}-${finalValue}-${diceAnimKey + 2000 + idx}`}
+                className="board-die-cube"
+                style={{
+                  '--end-rot-x': finalOrientation.x,
+                  '--end-rot-y': finalOrientation.y
+                }}
+              >
+                {renderFace(1, 'board-die-front')}
+                {renderFace(6, 'board-die-back')}
+                {renderFace(3, 'board-die-right')}
+                {renderFace(4, 'board-die-left')}
+                {renderFace(5, 'board-die-top')}
+                {renderFace(2, 'board-die-bottom')}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -327,7 +365,7 @@ function Bar({ state, playerStackSelected, playerStackMovable, highlighted, mova
   );
 }
 
-function BearOffTray({ label, count, highlighted, onClick, trayRef, className = '' }) {
+function BearOffTray({ label, count, pipCount, highlighted, onClick, trayRef, className = '' }) {
   return (
     <button
       ref={trayRef}
@@ -338,6 +376,7 @@ function BearOffTray({ label, count, highlighted, onClick, trayRef, className = 
     >
       <span className="tray-label">{label} Off</span>
       <span className="tray-count">{count}</span>
+      <span className="tray-meta">Pip {pipCount}</span>
     </button>
   );
 }
@@ -350,6 +389,7 @@ export default function App() {
   const [isAnimatingMove, setIsAnimatingMove] = useState(false);
   const [movingChecker, setMovingChecker] = useState(null);
   const [openingRollDisplay, setOpeningRollDisplay] = useState(null);
+  const [menuOpen, setMenuOpen] = useState(false);
   const boardStageRef = useRef(null);
   const pointRefs = useRef(new Map());
   const barRef = useRef(null);
@@ -839,6 +879,7 @@ export default function App() {
   }
 
   const statusText = openingRollDisplay?.message ?? (isAnimatingMove ? `${playerLabel(game.currentPlayer)} moving...` : describeRequiredAction(game, legalMoves));
+  const canRoll = !game.winner && !isComputerTurn && !isAnimatingMove && !isOpeningRollSequenceRunning && game.dice.remaining.length === 0;
 
   function renderPoint(point, isTop) {
     return (
@@ -875,38 +916,25 @@ export default function App() {
     <main className="app">
       <header className="header">
         <h1>Backgammon Local</h1>
-        <p className="subtitle">Play as Player against the computer, fully saved in your browser.</p>
       </header>
 
-      <section className="status" aria-live="polite">
-        <div><strong>Turn:</strong> {isComputerTurn ? 'Computer' : 'Player'}</div>
-        <div><strong>Action:</strong> {statusText}</div>
-        <DicePanel game={game} isBoardDiceRolling={isBoardDiceRolling} openingRollDisplay={openingRollDisplay} />
-      </section>
-
-      <section className="controls" aria-label="Game controls">
-        <button type="button" onClick={() => handleRoll()} aria-label="Roll Dice" disabled={game.winner || isComputerTurn || isAnimatingMove || isOpeningRollSequenceRunning || game.dice.remaining.length > 0}>
-          Roll Dice
-        </button>
-        <button type="button" onClick={handleNewGame} aria-label="New Game" disabled={isAnimatingMove}>New Game</button>
-        <button type="button" onClick={handleUndo} aria-label="Undo" disabled={isAnimatingMove || game.undoStack.length === 0}>Undo</button>
-        <button type="button" onClick={handleResetPosition} aria-label="Reset to Starting Position" disabled={isAnimatingMove}>Reset to Starting Position</button>
-        <button type="button" onClick={clearSavedGame} aria-label="Clear Saved Game" disabled={isAnimatingMove}>Clear Saved Game</button>
-      </section>
-
       <section ref={boardStageRef} className="board-stage" aria-label="Backgammon board">
+        <StatusChip text={statusText} />
+        <button
+          type="button"
+          className="icon-btn board-action-btn"
+          onClick={handleUndo}
+          aria-label="Undo"
+          disabled={isAnimatingMove || game.undoStack.length === 0}
+        >
+          ↶
+        </button>
+        <button type="button" className="icon-btn board-menu-btn" onClick={() => setMenuOpen(true)} aria-label="Open game menu">
+          ⚙
+        </button>
+
         <div className="board-shell">
           <div className="board-surface">
-            <div className="pip-board-row" aria-label="Pip counts">
-              <div className="pip-box pip-box-computer">
-                <span className="pip-box-label">Computer</span>
-                <span className="pip-box-value">PIP: {computerPipCount}</span>
-              </div>
-              <div className="pip-box pip-box-player">
-                <span className="pip-box-label">Player</span>
-                <span className="pip-box-value">PIP: {playerPipCount}</span>
-              </div>
-            </div>
             <div className="point-band top-band top-left-band">{TOP_LEFT.map((point) => renderPoint(point, true))}</div>
             <div className="point-band top-band top-right-band">{TOP_RIGHT.map((point) => renderPoint(point, true))}</div>
 
@@ -928,7 +956,14 @@ export default function App() {
 
             <div className="point-band bottom-band bottom-left-band">{BOTTOM_LEFT.map((point) => renderPoint(point, false))}</div>
             <div className="point-band bottom-band bottom-right-band">{BOTTOM_RIGHT.map((point) => renderPoint(point, false))}</div>
-            <BoardDice game={game} diceAnimKey={diceAnimKey} isBoardDiceRolling={isBoardDiceRolling} />
+            <BoardHUD
+              game={game}
+              diceAnimKey={diceAnimKey}
+              isBoardDiceRolling={isBoardDiceRolling}
+              openingRollDisplay={openingRollDisplay}
+              canRoll={canRoll}
+              onRoll={() => handleRoll()}
+            />
           </div>
 
           <aside className="home-rail" aria-label="Bear off area">
@@ -939,6 +974,7 @@ export default function App() {
                 bearOffRefs.current.B = node;
               }}
               count={game.bearOff.B}
+              pipCount={computerPipCount}
               highlighted={destinationSet.has('off') && game.currentPlayer === PLAYER_B}
               onClick={() => {
                 if (!isAnimatingMove && !isComputerTurn) {
@@ -953,6 +989,7 @@ export default function App() {
                 bearOffRefs.current.A = node;
               }}
               count={game.bearOff.A}
+              pipCount={playerPipCount}
               highlighted={destinationSet.has('off') && game.currentPlayer === PLAYER_A}
               onClick={() => {
                 if (!isAnimatingMove && !isComputerTurn) {
@@ -975,10 +1012,15 @@ export default function App() {
         )}
       </section>
 
-      <section className="debug" aria-label="Debug panel">
-        <button type="button" onClick={toggleDebug} aria-label="Toggle debug panel" className="debug-toggle">
-          {game.dev.debugOpen ? 'Hide Dev Tools' : 'Show Dev Tools'}
-        </button>
+      <MenuSheet open={menuOpen} onClose={() => setMenuOpen(false)}>
+        <div className="menu-actions">
+          <button type="button" onClick={handleNewGame} aria-label="New Game" disabled={isAnimatingMove}>New Game</button>
+          <button type="button" onClick={handleResetPosition} aria-label="Reset to Starting Position" disabled={isAnimatingMove}>Reset to Starting Position</button>
+          <button type="button" onClick={clearSavedGame} aria-label="Clear Saved Game" disabled={isAnimatingMove}>Clear Saved Game</button>
+          <button type="button" onClick={toggleDebug} aria-label="Toggle debug panel" className="menu-dev-toggle">
+            {game.dev.debugOpen ? 'Hide Dev Tools' : 'Show Dev Tools'}
+          </button>
+        </div>
 
         {game.dev.debugOpen && (
           <div className="debug-panel">
@@ -1013,7 +1055,7 @@ export default function App() {
             </button>
           </div>
         )}
-      </section>
+      </MenuSheet>
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,19 +1,26 @@
+
 :root {
-  --bg-top: #f5ecd6;
-  --bg-bottom: #dec396;
-  --panel: #fdf8ec;
-  --text: #1a1d22;
+  --bg: #f3f5f8;
+  --surface: #ffffff;
+  --text: #111827;
+  --muted: #6b7280;
+  --border: rgba(17, 24, 39, 0.12);
+  --primary: #1f6fff;
+  --primaryText: #ffffff;
+  --shadowSm: 0 4px 14px rgba(17, 24, 39, 0.08);
+  --shadowMd: 0 14px 36px rgba(17, 24, 39, 0.16);
+  --radiusSm: 12px;
+  --radiusMd: 14px;
+  --radiusLg: 16px;
   --wood-dark: #5f3d27;
   --wood-mid: #825538;
   --wood-light: #a66f48;
-  --felt: #caa16f;
   --triangle-a: #6f281f;
   --triangle-b: #f0dbb3;
   --checker-a1: #faf9f5;
   --checker-a2: #d7d4ca;
   --checker-b1: #1f2a36;
   --checker-b2: #3f4f60;
-  --accent: #ffd166;
   --focus: #3a90b3;
   --selected-outline: #2388ff;
   --selected-glow: rgba(35, 136, 255, 0.34);
@@ -25,199 +32,120 @@
   --stack-edge-gap: 0.08rem;
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
 body {
   margin: 0;
-  font-family: 'Palatino Linotype', 'Book Antiqua', 'Georgia', serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, sans-serif;
   color: var(--text);
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 20% 0%, rgba(255, 247, 232, 0.95) 0%, rgba(255, 247, 232, 0) 58%),
-    linear-gradient(165deg, var(--bg-top), var(--bg-bottom));
+  background: linear-gradient(180deg, #f8fafc 0%, #eef3f9 100%);
 }
 
 .app {
-  width: min(1220px, 100%);
+  width: min(1120px, 100%);
   margin: 0 auto;
-  padding: 1.1rem;
-}
-
-.header {
-  display: grid;
-  gap: 0.2rem;
+  padding: 0.9rem;
 }
 
 .header h1 {
-  margin: 0;
-  font-size: clamp(1.8rem, 2.2vw, 2.4rem);
-  letter-spacing: 0.02em;
-}
-
-.subtitle {
-  margin: 0.25rem 0 1rem;
-  color: rgba(26, 29, 34, 0.8);
-}
-
-.status {
-  background: linear-gradient(180deg, #fff8e8, #f7ead0);
-  border: 2px solid #6c4c30;
-  border-radius: 0.7rem;
-  padding: 0.8rem;
-  display: grid;
-  grid-template-columns: minmax(180px, 230px) 1fr auto;
-  gap: 0.8rem;
-  align-items: center;
-}
-
-.controls {
-  margin-top: 0.75rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-button {
-  cursor: pointer;
-  border: 2px solid #5b412d;
-  background: linear-gradient(180deg, #fff9ef, #f4e2c1);
-  border-radius: 0.55rem;
-  padding: 0.46rem 0.75rem;
-  font-size: 0.94rem;
-  color: #2a2219;
-}
-
-button:hover:not(:disabled) {
-  filter: brightness(1.04);
-}
-
-button:disabled {
-  opacity: 0.52;
-  cursor: not-allowed;
-}
-
-button:focus-visible {
-  outline: 3px solid var(--focus);
-  outline-offset: 1px;
-}
-
-.dice-panel {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-}
-
-.die {
-  width: 46px;
-  height: 46px;
-  border-radius: 0.55rem;
-  border: 2px solid #262626;
-  background: linear-gradient(145deg, #fff, #ece7df);
-  box-shadow: 0 3px 0 rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.9);
-  position: relative;
-  overflow: hidden;
-  display: grid;
-  place-items: center;
-}
-
-.die-used {
-  opacity: 0.5;
-  filter: grayscale(0.9) saturate(0.55);
-}
-
-.die-used .pip.on {
-  background: #3a3a3a;
-}
-
-.die-empty {
-  opacity: 0.35;
-}
-
-.die-grid {
-  width: 77%;
-  height: 77%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr);
-}
-
-.pip {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin: auto;
-  opacity: 0;
-}
-
-.pip.on {
-  opacity: 1;
-  background: #141414;
-}
-
-.remaining-dice {
-  margin-left: 0.35rem;
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.remaining-dice span {
-  min-width: 1.45rem;
-  text-align: center;
-  border-radius: 999px;
-  padding: 0.15rem 0.35rem;
-  background: #f4d8aa;
-  border: 1px solid #7b5837;
-  font-size: 0.82rem;
-  font-weight: 700;
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.2rem, 3vw, 1.5rem);
+  letter-spacing: 0.01em;
 }
 
 .board-stage {
   position: relative;
-  margin-top: 4.25rem;
+  margin-top: 0.4rem;
+  padding-top: 2.4rem;
 }
+
+.status-chip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 20;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--text);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadowSm);
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.icon-btn {
+  min-height: 44px;
+  min-width: 44px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--text);
+  box-shadow: var(--shadowSm);
+  display: inline-grid;
+  place-items: center;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.board-action-btn,
+.board-menu-btn {
+  position: absolute;
+  top: 0;
+  z-index: 21;
+}
+
+.board-action-btn { right: 3.2rem; }
+.board-menu-btn { right: 0; }
+
+button {
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radiusMd);
+  padding: 0.6rem 0.9rem;
+  font-size: 0.95rem;
+  color: var(--text);
+  min-height: 44px;
+}
+
+button:hover:not(:disabled) { filter: brightness(0.98); }
+button:active:not(:disabled) { transform: translateY(1px); }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+button:focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
 
 .board-shell {
   display: grid;
-  grid-template-columns: 1fr minmax(95px, 118px);
+  grid-template-columns: 1fr;
   gap: 0.75rem;
   align-items: stretch;
 }
 
 .home-rail {
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem;
   min-height: 100%;
 }
 
 .bearoff-tray {
-  border-radius: 0.8rem;
-  border: 3px solid #3f2918;
-  background:
-    linear-gradient(180deg, rgba(255, 240, 214, 0.44), rgba(0, 0, 0, 0.09)),
-    linear-gradient(145deg, #9a6541, #6f482e);
-  color: #fff8e5;
+  border-radius: var(--radiusLg);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadowSm);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  gap: 0.55rem;
+  gap: 0.3rem;
+  padding: 0.8rem;
 }
 
-.tray-label {
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  opacity: 0.95;
-}
-
-.tray-count {
-  font-size: clamp(1.7rem, 2.5vw, 2.2rem);
-  font-weight: 700;
-}
+.tray-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.tray-count { font-size: clamp(1.5rem, 2.4vw, 2rem); font-weight: 700; }
+.tray-meta { font-size: 0.82rem; color: var(--muted); }
 
 .board-surface {
   position: relative;
@@ -227,152 +155,142 @@ button:focus-visible {
   column-gap: 0.42rem;
   row-gap: 0;
   padding: 0.62rem;
-  border-radius: 1rem;
-  border: 4px solid #3a2618;
+  border-radius: var(--radiusLg);
+  border: 1px solid rgba(58, 38, 24, 0.45);
   background:
-    linear-gradient(180deg, rgba(255, 245, 228, 0.23), rgba(0, 0, 0, 0.22)),
+    linear-gradient(180deg, rgba(255, 245, 228, 0.2), rgba(0, 0, 0, 0.2)),
     linear-gradient(145deg, var(--wood-light), var(--wood-mid) 46%, var(--wood-dark));
-  box-shadow: 0 10px 18px rgba(45, 25, 10, 0.25);
+  box-shadow: var(--shadowMd);
 }
 
-.pip-board-row {
+.board-hud-overlay {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: -58px;
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  pointer-events: none;
-  z-index: 12;
-}
-
-.pip-box {
-  min-width: 140px;
-  border-radius: 0.6rem;
-  border: 2px solid #2f1e13;
-  background: linear-gradient(180deg, #fff8e8, #ead0a5);
-  color: #2a2219;
-  box-shadow: 0 5px 10px rgba(31, 18, 8, 0.28);
-  padding: 0.4rem 0.65rem;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-.pip-box-player {
-  align-items: flex-end;
-  text-align: right;
-}
-
-.pip-box-label {
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  opacity: 0.88;
-}
-
-.pip-box-value {
-  font-size: 1.08rem;
-  font-weight: 700;
-  line-height: 1.1;
-}
-
-.board-dice-overlay {
-  position: absolute;
-  left: calc(50% + (var(--bar-column-width) / 2) + 0.42rem);
-  right: 0;
+  right: 0.55rem;
   top: 50%;
   transform: translateY(-50%);
   display: flex;
-  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.55rem;
+  z-index: 11;
+}
+
+.roll-cta {
+  background: var(--primary);
+  color: var(--primaryText);
+  border: none;
+  box-shadow: var(--shadowSm);
+  border-radius: 999px;
+  min-width: 84px;
+  font-weight: 700;
+}
+
+.dice-state-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--border);
+  border-radius: var(--radiusMd);
+  box-shadow: var(--shadowSm);
+  padding: 0.45rem;
+}
+
+.dice-state-title {
+  display: block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 0.35rem;
+}
+
+.dice-panel,
+.board-dice-overlay {
+  display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.55rem;
-  pointer-events: none;
-  z-index: 10;
+  gap: 0.4rem;
 }
 
-.board-die-perspective {
-  width: 48px;
-  height: 48px;
-  perspective: 900px;
-}
-
-.board-die-cube {
-  width: 100%;
-  height: 100%;
+.die {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.28);
+  background: linear-gradient(145deg, #fff, #eceff3);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
   position: relative;
-  transform-style: preserve-3d;
-  animation: dieCubeRoll 1s cubic-bezier(0.26, 0.8, 0.33, 1) forwards;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
 }
 
-.board-die-used {
-  opacity: 0.5;
-  filter: grayscale(0.9) saturate(0.55);
-}
+.die-used { opacity: 0.42; transform: scale(0.95); }
+.die-grid { width: 77%; height: 77%; display: grid; grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(3, 1fr); }
+.pip { width: 7px; height: 7px; border-radius: 50%; margin: auto; opacity: 0; }
+.pip.on { opacity: 1; background: #141414; }
 
-.board-die-used .board-face-pip.on {
-  background: #3a3a3a;
-}
-
+.board-die-perspective { width: 40px; height: 40px; perspective: 900px; }
+.board-die-cube { width: 100%; height: 100%; position: relative; transform-style: preserve-3d; animation: dieCubeRoll 1s cubic-bezier(0.26, 0.8, 0.33, 1) forwards; }
+.board-die-used { opacity: 0.42; transform: scale(0.95); }
 .board-die-face {
   position: absolute;
   width: 100%;
   height: 100%;
-  border-radius: 0.5rem;
-  border: 2px solid #262626;
-  background: linear-gradient(145deg, #fff, #ece7df);
-  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.28);
+  background: linear-gradient(145deg, #fff, #eceff3);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
   display: grid;
   place-items: center;
   backface-visibility: hidden;
 }
+.board-face-grid { width: 76%; height: 76%; display: grid; grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(3, 1fr); }
+.board-face-pip { width: 7px; height: 7px; border-radius: 50%; margin: auto; opacity: 0; background: #141414; }
+.board-face-pip.on { opacity: 1; }
 
-.board-face-grid {
-  width: 76%;
-  height: 76%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr);
+.board-die-front { transform: rotateY(0deg) translateZ(20px); }
+.board-die-back { transform: rotateY(180deg) translateZ(20px); }
+.board-die-right { transform: rotateY(90deg) translateZ(20px); }
+.board-die-left { transform: rotateY(-90deg) translateZ(20px); }
+.board-die-top { transform: rotateX(90deg) translateZ(20px); }
+.board-die-bottom { transform: rotateX(-90deg) translateZ(20px); }
+
+.menu-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  align-items: flex-end;
+  z-index: 40;
 }
 
-.board-face-pip {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin: auto;
-  opacity: 0;
-  background: #141414;
+.menu-sheet {
+  width: 100%;
+  background: var(--surface);
+  border-radius: 18px 18px 0 0;
+  padding: 0.8rem;
+  box-shadow: var(--shadowMd);
+}
+.menu-sheet-handle { width: 40px; height: 4px; border-radius: 999px; background: #d1d5db; margin: 0 auto 0.6rem; }
+.menu-sheet-header { display: flex; align-items: center; justify-content: space-between; }
+.menu-sheet-header h2 { margin: 0; font-size: 1rem; }
+.menu-actions { display: grid; gap: 0.5rem; margin-top: 0.5rem; }
+.menu-dev-toggle { background: #eef4ff; }
+
+.debug-panel {
+  margin-top: 0.75rem;
+  background: #f8fafc;
+  border: 1px solid var(--border);
+  border-radius: var(--radiusMd);
+  padding: 0.65rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
 }
 
-.board-face-pip.on {
-  opacity: 1;
-}
-
-.board-die-front {
-  transform: rotateY(0deg) translateZ(24px);
-}
-
-.board-die-back {
-  transform: rotateY(180deg) translateZ(24px);
-}
-
-.board-die-right {
-  transform: rotateY(90deg) translateZ(24px);
-}
-
-.board-die-left {
-  transform: rotateY(-90deg) translateZ(24px);
-}
-
-.board-die-top {
-  transform: rotateX(90deg) translateZ(24px);
-}
-
-.board-die-bottom {
-  transform: rotateX(-90deg) translateZ(24px);
-}
+.debug-fields { display: flex; gap: 0.7rem; }
+.debug-fields label { display: flex; flex-direction: column; font-size: 0.88rem; gap: 0.2rem; }
+.debug-fields input { width: 72px; padding: 0.3rem; border: 1px solid var(--border); border-radius: 8px; }
 
 .point-band {
   display: grid;
@@ -666,55 +584,6 @@ button:focus-visible {
     0 0 12px 1px var(--selected-glow);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .point.selected .checker-stack,
-  .point.is-selected .checker-stack,
-  .barForcedSelected .bar-checker:first-child {
-    transition: none;
-    transform: none;
-    will-change: auto;
-  }
-}
-
-.debug {
-  margin-top: 1rem;
-}
-
-.debug-toggle {
-  background: #d9e8ef;
-}
-
-.debug-panel {
-  margin-top: 0.5rem;
-  background: var(--panel);
-  border: 2px solid #6f4d30;
-  border-radius: 0.65rem;
-  padding: 0.65rem;
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-
-.debug-fields {
-  display: flex;
-  gap: 0.7rem;
-}
-
-.debug-fields label {
-  display: flex;
-  flex-direction: column;
-  font-size: 0.88rem;
-  gap: 0.2rem;
-}
-
-.debug-fields input {
-  width: 72px;
-  padding: 0.3rem;
-  border: 1px solid #5c3f2a;
-  border-radius: 0.35rem;
-}
-
 @keyframes dieRoll {
   0% {
     transform: rotate(0deg) scale(0.9);
@@ -751,272 +620,57 @@ button:focus-visible {
   }
 }
 
-@media (max-width: 1080px) {
-  .status {
-    grid-template-columns: 1fr;
-  }
-
+@media (min-width: 940px) {
   .board-shell {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr minmax(108px, 132px);
   }
 
   .home-rail {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: 1fr;
-  }
-
-  .bearoff-tray,
-  .home-rail .bearoff-tray {
-    min-height: 86px;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
   }
 }
 
 @media (max-width: 760px) {
-  .board-stage {
-    margin-top: 3.7rem;
-  }
-
-  .pip-board-row {
-    top: -52px;
-  }
-
-  .pip-box {
-    min-width: 118px;
-    padding: 0.34rem 0.5rem;
-  }
-
-  .pip-box-value {
-    font-size: 0.98rem;
-  }
-
-  .app {
-    padding: 0.7rem;
-  }
-
-  .header h1 {
-    font-size: clamp(1.38rem, 7vw, 1.72rem);
-  }
-
-  .subtitle {
-    margin-bottom: 0.7rem;
-    font-size: 0.94rem;
-  }
-
-  button {
-    min-height: 42px;
-  }
-
-  .board-surface {
-    --bar-column-width: clamp(14px, 3.8vw, 20px);
-    grid-template-rows: minmax(128px, 1fr) clamp(44px, 10vw, 58px) minmax(128px, 1fr);
-    padding: 0.46rem;
-    border-width: 3px;
-  }
-
-  .point {
-    min-height: clamp(118px, 35vw, 150px);
-  }
-
-  .point-band {
-    gap: 0.22rem;
-  }
-
-  .board-dice-overlay {
-    gap: 0.4rem;
-  }
-
-  .board-die-perspective {
-    width: 38px;
-    height: 38px;
-  }
-
-  .board-die-face {
-    border-width: 1.5px;
-  }
-
-  .board-face-pip {
-    width: 6px;
-    height: 6px;
-  }
-
-  .board-die-front {
-    transform: rotateY(0deg) translateZ(19px);
-  }
-
-  .board-die-back {
-    transform: rotateY(180deg) translateZ(19px);
-  }
-
-  .board-die-right {
-    transform: rotateY(90deg) translateZ(19px);
-  }
-
-  .board-die-left {
-    transform: rotateY(-90deg) translateZ(19px);
-  }
-
-  .board-die-top {
-    transform: rotateX(90deg) translateZ(19px);
-  }
-
-  .board-die-bottom {
-    transform: rotateX(-90deg) translateZ(19px);
-  }
-
-  .checker {
-    --checker-size: clamp(20px, 6vw, 30px);
-  }
-
-}
-
-@media (max-width: 560px) {
-  .board-stage {
-    margin-top: 3.2rem;
-  }
-
-  .pip-board-row {
-    top: -46px;
-  }
-
-  .pip-box {
-    min-width: 98px;
-    border-width: 1.5px;
-    border-radius: 0.5rem;
-    padding: 0.28rem 0.42rem;
-  }
-
-  .pip-box-label {
-    font-size: 0.66rem;
-  }
-
-  .pip-box-value {
-    font-size: 0.86rem;
-  }
-
   :root {
-    --board-center-gap: 44px;
-    --bar-column-width: clamp(14px, 4.2vw, 18px);
+    --board-center-gap: 48px;
+    --bar-column-width: clamp(12px, 4.2vw, 18px);
     --stack-edge-gap: 0.04rem;
   }
 
-  .app {
-    padding: 0.5rem;
-  }
-
-  .status {
-    padding: 0.65rem;
-    gap: 0.55rem;
-  }
-
-  .controls {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.45rem;
-  }
-
-  .controls button {
-    width: 100%;
-    padding: 0.5rem;
-    font-size: 0.9rem;
-  }
-
-  .dice-panel {
-    gap: 0.4rem;
-    flex-wrap: wrap;
-  }
-
-  .die {
-    width: 40px;
-    height: 40px;
-  }
-
-  .board-shell {
-    gap: 0.55rem;
-  }
+  .app { padding: 0.6rem; }
+  .board-stage { padding-top: 2.8rem; }
+  .status-chip { max-width: calc(100% - 6.2rem); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
   .board-surface {
-    grid-template-rows: minmax(104px, 1fr) var(--board-center-gap) minmax(104px, 1fr);
-    padding: 0.33rem;
-    border-width: 2px;
-    border-radius: 0.78rem;
+    grid-template-rows: minmax(112px, 1fr) var(--board-center-gap) minmax(112px, 1fr);
+    padding: 0.4rem;
   }
 
-  .point-band {
-    gap: 0.16rem;
-  }
-
-  .point {
-    min-height: clamp(92px, 24vw, 118px);
-  }
-
-  .point::before {
-    width: 94%;
-  }
-
-  .checker {
-    --checker-size: clamp(14px, 4.6vw, 22px);
-    border-width: 1.5px;
-  }
-
-  .tray-label {
-    font-size: 0.72rem;
-  }
-
-  .tray-count {
-    font-size: clamp(1.2rem, 4.8vw, 1.55rem);
-  }
-
-  .board-dice-overlay {
-    top: 50%;
-    gap: 0.28rem;
-  }
-
-  .board-die-perspective {
-    width: 30px;
-    height: 30px;
-  }
-
-  .board-face-pip {
-    width: 4px;
-    height: 4px;
-  }
-
-  .board-die-front {
-    transform: rotateY(0deg) translateZ(15px);
-  }
-
-  .board-die-back {
-    transform: rotateY(180deg) translateZ(15px);
-  }
-
-  .board-die-right {
-    transform: rotateY(90deg) translateZ(15px);
-  }
-
-  .board-die-left {
-    transform: rotateY(-90deg) translateZ(15px);
-  }
-
-  .board-die-top {
-    transform: rotateX(90deg) translateZ(15px);
-  }
-
-  .board-die-bottom {
-    transform: rotateX(-90deg) translateZ(15px);
-  }
+  .point { min-height: clamp(96px, 28vw, 122px); }
+  .point-band { gap: 0.18rem; }
+  .board-hud-overlay { right: 0.35rem; }
+  .die,
+  .board-die-perspective { width: 30px; height: 30px; }
+  .board-face-pip,
+  .pip { width: 4px; height: 4px; }
+  .board-die-front { transform: rotateY(0deg) translateZ(15px); }
+  .board-die-back { transform: rotateY(180deg) translateZ(15px); }
+  .board-die-right { transform: rotateY(90deg) translateZ(15px); }
+  .board-die-left { transform: rotateY(-90deg) translateZ(15px); }
+  .board-die-top { transform: rotateX(90deg) translateZ(15px); }
+  .board-die-bottom { transform: rotateX(-90deg) translateZ(15px); }
 }
 
-@media (max-width: 420px) {
-  .controls {
-    grid-template-columns: 1fr;
-  }
-
-  .home-rail {
-    gap: 0.45rem;
-  }
-
-  .bearoff-tray,
-  .home-rail .bearoff-tray {
-    min-height: 74px;
+@media (prefers-reduced-motion: reduce) {
+  .board-die-cube,
+  .moving-checker,
+  .point.selected .checker-stack,
+  .point.is-selected .checker-stack,
+  .barForcedSelected .bar-checker:first-child {
+    animation: none;
+    transition: none;
+    transform: none;
+    will-change: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- Refresh the app UI to a clean, mobile-first, board-centric design while keeping all game rules and logic unchanged.  
- Reduce visual chrome and make the board the hero by replacing the large top status/control panels with contextual on-board controls.  
- Provide lightweight, touch-friendly controls and a small menu for secondary actions to improve usability on small screens.  

### Description
- Reworked top-level layout in `src/App.jsx` by removing the large status panel and controls and introducing `StatusChip`, `BoardHUD`, and `MenuSheet` components to surface status, dice/moves and contextual actions on or near the board.  
- Moved dice display and remaining-moves UI onto the board as an overlay (`BoardHUD` + updated `BoardDice`) and preserved the existing dice roll animation path and usage state (used dice are visually faded/shrunk).  
- Consolidated secondary actions (`New Game`, `Reset to Starting Position`, `Clear Saved Game`, Dev Tools) into a small gear-triggered bottom-sheet menu (`MenuSheet`) and added a small always-available `Undo` icon button near the board.  
- Integrated pip counts into the bear-off trays (`BearOffTray`) and removed the standalone pip/top status chrome to reduce vertical clutter.  
- Replaced the old styling with a modern design system in `src/styles.css` using CSS variables (color, radius, shadow tokens such as `--primary`, `--surface`, `--shadowSm`, `--radiusMd`), soft borders, larger rounded corners, subtle shadows and mobile-first responsive rules.  
- Added accessibility and polish: clear pressed states, >=44px touch targets for icon buttons, and `prefers-reduced-motion` handling to disable dice/move animations when requested; all changes are strictly presentational and do not alter game logic.  

### Testing
- Built a production bundle with `npm run build` and the build completed successfully.  
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the redesigned UI by capturing a mobile viewport screenshot with Playwright.  
- No game logic/unit tests were changed; the changes were validated via build and a visual smoke test only, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b92cc224832ebe43a64f7baf2241)