### PR TITLE
Add comprehensive handoff documentation and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+## Local setup
+
+```bash
+npm install
+npm run dev
+```
+
+Build check before sharing changes:
+
+```bash
+npm run build
+npm run preview
+```
+
+## Scope guardrails
+
+This project separates **rules/state logic** and **UI behavior**:
+
+- Rules/state transitions live in `src/game.js`.
+- Rendering/interaction/animation lives in `src/App.jsx` + `src/styles.css`.
+
+For UI-focused contributions, avoid changing rule logic unless explicitly requested. Prefer CSS/class/markup improvements and keep gameplay behavior identical.
+
+## How to make UI changes without changing rules
+
+- Do not modify `computeLegalMoves`, `applyMove`, `rollDice`, `canBearOff`, or related helpers in `src/game.js` for visual tasks.
+- If you need new visual states, derive them from existing state fields in `App.jsx`.
+- Preserve current interaction semantics:
+  - selectable sources,
+  - destination highlighting,
+  - forced bar entry,
+  - dice consumption indicators.
+
+## Suggested manual test checklist
+
+Run through this list in the browser after UI changes:
+
+- **Rolling**: opening roll flow + normal roll flow behaves correctly.
+- **Doubles**: doubles create four usable dice and consume correctly.
+- **Bar entry**: if player has checker(s) on bar, only bar entry is allowed.
+- **Hitting**: moving onto a single opposing checker sends it to bar.
+- **Bearing off**: only allowed when all checkers are in home; oversized die behavior works as expected.
+- **Undo**: undo restores prior state and can be applied repeatedly.
+- **Persistence**: refresh page and confirm state resumes from localStorage.
+
+## Code style notes
+
+- Match existing code style and naming in each file.
+- Keep functions small and explicit.
+- Prefer existing helpers over introducing new abstractions unless necessary.
+- Keep docs and UI text concise and user-facing.

--- a/README.md
+++ b/README.md
@@ -1,68 +1,46 @@
-# Backgammon Local (Frontend Only)
+# Backgammon Local
 
-A complete backgammon web app that runs fully in the browser, with Player B controlled by a computer AI.
+Backgammon Local is a single-page React + Vite application for playing backgammon in the browser against a built-in computer opponent. The app keeps all rules, turn progression, move generation, and AI move selection on the client, with no API calls or backend services.
 
-## Tech
-- React + Vite
-- No backend
-- No external services
-- State persisted to `window.localStorage` under `backgammon.save.v1`
+The codebase is intentionally compact: `src/game.js` contains core game/state logic, while `src/App.jsx` owns UI composition, user interaction flow, animation timing, and persistence wiring. The app is designed to be easy to hand off and extend safely, especially for UI and UX improvements that should not alter core rules.
 
-## Features
-- Standard 24-point board with bar and bear-off trays
-- Classic wood-style board visuals with triangular points and styled checker stacks
-- Standard starting position
-- Dice rolling with doubles handled as 4 moves
-- Graphical dice faces with roll animation and remaining-move chips
-- Legal move generation with:
-  - blocked points (2+ opponent checkers)
-  - hitting blots (single checker)
-  - mandatory bar entry before other moves
-  - bearing off rules including oversized die when no checker behind
-  - forced higher die when only one die can be played
-- Click-to-play interaction:
-  - select source checker stack (or bar)
-  - legal destinations highlighted
-  - click destination to move
-- Computer opponent:
-  - Player A is human
-  - Player B auto-rolls and auto-plays legal moves using a lightweight heuristic AI
-- Turn progression and automatic pass when no legal moves exist after a roll
-- Undo stack (serializable, persisted)
-- Controls:
-  - Roll Dice
-  - New Game
-  - Undo
-  - Reset to Starting Position
-  - Clear Saved Game
-- Dev/debug panel to set deterministic dice rolls
+## Key constraints
+
+- **Frontend-only**: no server-side code, network API, or database.
+- **Persistence uses only `localStorage`** via `STORAGE_KEY = backgammon.save.v1`.
+- **No backend contract**: all validation and state transitions happen in browser code.
 
 ## Run locally
-1. Install dependencies:
+
 ```bash
 npm install
-```
-2. Start dev server:
-```bash
 npm run dev
 ```
-3. Build production bundle:
+
+Then open the local Vite URL (default `http://localhost:5173`).
+
+## Build and preview
+
 ```bash
 npm run build
-```
-4. Preview production build:
-```bash
 npm run preview
 ```
 
-## Test on mobile
-1. Start Vite on your LAN so your phone can reach it:
-```bash
-npm run dev -- --host
-```
-2. In the terminal output, open the `Network` URL on your phone (same Wi-Fi), for example `http://192.168.x.x:5173`.
-3. For quick desktop simulation, open browser dev tools and toggle device emulation (responsive mode).
+## High-level folder structure
 
-## Notes
-- The app automatically saves after every state change.
-- On load, it restores from localStorage when schema version matches; otherwise it safely starts a new game.
+- `src/main.jsx` — React entry point and app mount.
+- `src/App.jsx` — UI layout, interaction handling, animation flow, and computer-turn orchestration.
+- `src/game.js` — game rules, legal move computation, turn transitions, undo snapshots, serialization/hydration.
+- `src/styles.css` — board visuals, checker/dice styling, highlight system, and responsive/mobile layout rules.
+- `docs/` — handoff documentation for architecture, rules, state machine, and roadmap.
+
+## How to play (app summary)
+
+1. Start a new game and use **Roll Dice** to resolve opening roll and normal turns.
+2. On your turn, click a highlighted source checker (or your checker on the bar) to select it.
+3. Click a highlighted destination to move. If only one legal move path exists, the app resolves it automatically.
+4. If you have checkers on the bar, you must re-enter from the bar before moving other checkers.
+5. Bear off once all your checkers are in your home board.
+6. Use **Undo** to step back one snapshot, or **Reset to Starting Position / Clear Saved Game** for resets.
+
+For rule-level details, see [`docs/RULES.md`](docs/RULES.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,60 @@
+# Architecture
+
+## Overview
+
+The app is a client-only React application with one primary stateful component (`App`) and one game logic module (`game.js`). The architecture intentionally keeps deterministic rule logic outside the React component tree.
+
+## Main modules
+
+- `src/main.jsx`
+  - Mounts `<App />` under `React.StrictMode`.
+- `src/App.jsx`
+  - Owns React state (`game`, selection, animation flags, debug panel values).
+  - Computes legal moves via `computeLegalMoves(game)` and derives UI affordances (movable sources, destinations).
+  - Handles user actions (roll, select source, select destination, undo, reset, clear save).
+  - Orchestrates computer turns and move animations.
+- `src/game.js`
+  - Canonical game rules and state transition functions.
+  - Move generation and legality filtering.
+  - AI move choice helper.
+  - Serialization + restoration and schema validation.
+
+## Data flow and ownership
+
+1. `App` stores the canonical `game` state in React (`useState(loadInitial)`).
+2. Any user/computer action calls pure transition helpers in `game.js`.
+3. Resulting state is committed with `setGame`, typically wrapped with `pushUndoState`.
+4. `App` derives render-time views (`legalMoves`, source/destination maps, pip counts).
+5. A `useEffect` writes serialized state to localStorage after each game change.
+
+## Rules vs rendering boundaries
+
+- **Rules/state** (`game.js`):
+  - starting position,
+  - move generation,
+  - bar entry requirements,
+  - blocked points/hits,
+  - bearing off eligibility,
+  - winner detection,
+  - undo snapshots,
+  - schema-checked restore.
+- **UI/rendering** (`App.jsx`, `styles.css`):
+  - board layout and checker visuals,
+  - highlight classes and interactions,
+  - dice display/animation,
+  - async timing for opening/computer turns,
+  - control buttons and debug panel.
+
+## localStorage strategy
+
+- Storage key: `backgammon.save.v1` (`STORAGE_KEY`).
+- Save trigger: every `game` state change (`useEffect` in `App.jsx`).
+- Hydration: `loadInitial()` reads localStorage and calls `restoreState(raw)`.
+- Fallback: invalid/missing/incompatible saved data returns a fresh initial state.
+
+## State versioning
+
+- Version field is embedded in state (`version`).
+- `SCHEMA_VERSION` is currently `1`.
+- `restoreState` rejects saves with mismatched version or invalid shape.
+- Current strategy is simple hard rejection + reset to default state (no migration layer yet).

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,45 @@
+# Data Model
+
+This app uses a single serializable game object (see `createInitialState` in `src/game.js`).
+
+## Primary fields
+
+- `version: number`
+  - Schema version for save/restore validation.
+- `points: number[24]`
+  - Signed checker counts per point.
+  - `> 0` = Player A count, `< 0` = Player B count, `0` = empty.
+- `bar: { A: number, B: number }`
+  - Captured checkers waiting to re-enter.
+- `bearOff: { A: number, B: number }`
+  - Checkers removed from board.
+- `currentPlayer: 'A' | 'B'`
+  - Side to act.
+- `dice: { values: number[], remaining: number[] }`
+  - `values` = rolled pair display.
+  - `remaining` = consumable die list (including expanded doubles).
+- `winner: null | 'A' | 'B'`
+- `openingRollPending: boolean`
+- `undoStack: GameState[]` (snapshots with nested undo removed before storage)
+- `statusText: string`
+- `dev: { debugOpen: boolean, dieA: number, dieB: number }`
+
+## Invariants
+
+- `points.length === 24`.
+- Point values are integers and bounded by checker totals.
+- A side’s active checkers are represented by sign, never mixed ownership on one point.
+- If `bar[player] > 0`, legal moves for that player must originate from `bar`.
+- `winner` is set when `bearOff.A >= 15` or `bearOff.B >= 15`.
+- `dice.remaining` is source of truth for remaining move resources.
+
+## Common pitfalls
+
+- Confusing `dice.values` (display roll) with `dice.remaining` (action budget).
+- Editing `points` directly in UI code instead of using transition helpers.
+- Forgetting that oversized bear-off is conditional (“no checker behind”).
+- Treating undo snapshots as fully recursive (they are intentionally stripped via `stripForUndo`).
+
+## Save/restore validation
+
+`restoreState` rejects malformed or mismatched saves and falls back to default initial state. This keeps persistence robust while using a simple schema gate.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,23 @@
+# Decisions (ADR-lite)
+
+- **Frontend-only implementation**
+  - Keep deployment simple and offline-friendly.
+  - Avoid backend complexity for a single-device game experience.
+
+- **localStorage-only persistence**
+  - Save complete state on each change for instant resume.
+  - Use schema version guard to reject incompatible saves safely.
+
+- **Thin bar seam + overlay stacks**
+  - Preserve clear board centerline while still showing bar checkers.
+  - Improves readability versus a wide opaque bar lane.
+
+- **Dice + move UI strategy**
+  - Source-first interaction (pick checker, then destination).
+  - Distinct highlight hierarchy for movable/selected/destination.
+  - Used dice are visually greyed to reinforce remaining move budget.
+
+- **Intentional non-goals (current scope)**
+  - No doubling cube or match-scoring system.
+  - No online multiplayer.
+  - No advanced analysis engine or exhaustive AI search.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+## Near-term (practical UI/UX improvements)
+
+- Improve keyboard accessibility and visible focus navigation across board points and controls.
+- Add richer screen-reader announcements for move results, hits, and forced bar-entry prompts.
+- Polish animation timing/easing and optional animation toggle.
+- Add lightweight in-app help modal linking to rules and controls.
+- Continue mobile ergonomics tuning (tap spacing, contrast, text scaling).
+
+## Mid-term
+
+- Improve computer opponent quality (deeper lookahead or pluggable strategy profiles).
+- Add optional move hints / post-move evaluation for learning mode.
+- Introduce match play scaffolding (multi-game score tracking, configurable target points).
+- Add optional rule toggles if needed (without changing default behavior).
+
+## Out of scope for now
+
+- Server-backed multiplayer.
+- Real-money or rating systems.
+- Heavy analytics infrastructure.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,0 +1,84 @@
+# Rules Implemented in This App
+
+This document reflects the currently implemented behavior in `src/game.js`.
+
+## Players and board model
+
+- `PLAYER_A` is the human player (`Player` in UI).
+- `PLAYER_B` is the computer opponent (`Computer` in UI).
+- Board uses 24 points indexed `0..23` with signed checker counts:
+  - positive = Player A,
+  - negative = Player B.
+
+## Opening roll
+
+- Game starts in `openingRollPending` mode.
+- Each side rolls one die.
+- On tie: no move starts; opening roll repeats.
+- Higher die becomes starting player; those two dice become the first turn's usable dice.
+
+## Rolling and doubles
+
+- Normal turn roll yields two dice.
+- If dice are equal (doubles), `dice.remaining` becomes four entries of that value.
+- Dice are consumed one move at a time by matching `dieUsed`.
+
+## Legal move generation behavior
+
+The app searches move paths over remaining dice and enforces “maximum playable moves” behavior:
+
+- It computes all reachable move paths with the current dice.
+- It allows only first moves that belong to longest achievable paths.
+- Special case: with two different dice where only one checker move is possible, if each die is individually playable, the higher die must be used.
+
+## Forced bar entry
+
+- If current player has any checker on bar (`bar[player] > 0`), only bar-entry moves are generated.
+- Entry point is determined by die and player direction.
+- Entry is illegal if destination point is blocked by 2+ opponent checkers.
+
+## Hitting
+
+- Landing on an opponent blot (single checker) is allowed.
+- Hit behavior:
+  - destination point is cleared,
+  - opponent bar count increments,
+  - moving checker occupies that point.
+
+## Bearing off
+
+Bearing off is allowed only when:
+
+1. Current player has no checkers on the bar.
+2. All of that player's in-play checkers are inside their home board.
+
+Exact bear-off logic:
+
+- Exact die usage bears off from matching distance-to-exit.
+- Oversized die can bear off from a lower point only when no checker exists on a point farther from the exit (i.e., “no checker behind” rule).
+
+## Turn end and no-legal-move handling
+
+- After each move, if no dice remain or no additional legal move exists, turn ends automatically.
+- Immediately after a roll, if no legal moves exist, turn is passed automatically.
+
+## Win condition
+
+- First side to bear off 15 checkers wins.
+
+## Not implemented
+
+- Doubling cube / stakes.
+- Match play (multi-game scoring, Crawford, gammon/backgammon scoring variants).
+- Online multiplayer/network sync.
+- Full legal-rules variants configuration.
+
+## Assumptions / confirm-in-code pointers
+
+If behavior ever looks inconsistent, verify these functions in `src/game.js`:
+
+- `computeLegalMoves`
+- `generateSingleDieMoves`
+- `canBearOff`
+- `canUseOversizedBearOff`
+- `applyMove`

--- a/docs/STATE_MACHINE.md
+++ b/docs/STATE_MACHINE.md
@@ -1,0 +1,54 @@
+# Turn State Machine
+
+This is a conceptual state machine mapped to current app behavior.
+
+## Core flow
+
+```text
+OpeningRoll
+  -> TurnStart
+  -> Roll
+  -> SelectFrom
+  -> SelectTo/Move
+  -> DiceConsumed
+  -> TurnEnd
+  -> TurnStart (next player)
+```
+
+## Phase notes
+
+- **OpeningRoll**
+  - Triggered by initial game state (`openingRollPending = true`).
+  - Tie loops back to OpeningRoll.
+  - Non-tie sets `currentPlayer`, seeds first `dice.remaining`, exits opening phase.
+
+- **TurnStart**
+  - Active player has no remaining dice yet.
+  - Waiting for roll (human click) or auto-roll (computer timer).
+
+- **Roll**
+  - Dice values + remaining dice populated.
+  - If no legal moves exist, transition directly to TurnEnd (pass).
+
+- **SelectFrom** (human) / **ChooseMove** (computer)
+  - Source options are constrained to legal moves.
+  - If checker(s) on bar, source is forced to bar entry only.
+
+- **SelectTo/Move**
+  - Destination chosen and one move applied.
+  - App may chain move animation for selected path option.
+
+- **DiceConsumed**
+  - Used die removed from `dice.remaining`.
+  - Recompute legal moves for same player.
+  - If dice remain and legal moves exist, loop back to SelectFrom.
+
+- **TurnEnd**
+  - Triggered when dice exhausted or no legal continuation.
+  - `currentPlayer` toggles, dice reset to empty, status updated.
+
+## Special cases
+
+- **No legal moves after roll**: automatic pass to next player.
+- **Forced bar entry**: blocks all non-bar sources until bar is empty.
+- **Winner reached**: state machine effectively halts normal turn progression.

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -1,0 +1,46 @@
+# UI Interaction Guide
+
+## Interaction model
+
+The board interaction is source-first:
+
+1. User rolls.
+2. User selects a legal source checker stack (or bar checker).
+3. App highlights legal destinations.
+4. User clicks destination to execute move (with animation unless reduced-motion preference is set).
+
+## Highlight hierarchy
+
+Current visual priority is:
+
+1. **Selected source** (dominant blue)
+   - `.selected` / `.is-selected`
+   - Strong blue inset outline + glow.
+2. **Movable sources** (subtle gold)
+   - `.checker-movable`
+   - Gold ring/glow on top checker.
+3. **Legal destinations** (thin gold)
+   - `.legal` / `.is-legal`
+   - Thin gold inset outline + soft glow.
+
+If a target is both selected and legal, selected styling dominates.
+
+## Dice indicators
+
+- Rolled dice are shown in status and board overlay.
+- Used dice are visually dimmed via `.die-used` / `.board-die-used`.
+- Doubles are expanded to four visible dice when appropriate, matching remaining usage.
+
+## Bar presentation
+
+- The center bar uses a deliberately thin seam (`.bar-seam`) rather than a wide lane.
+- Captured checkers are rendered in an overlay (`.bar-checker-overlay`) on top of that seam.
+- Computer stack is anchored from the top (`.barStackTop`), player stack from the bottom (`.barStackBottom`).
+- Player’s topmost bar checker is interactive when bar entry is required.
+
+## Mobile-first and controls philosophy
+
+- Layout compresses progressively through media queries (`1080px`, `760px`, `560px`, `420px`).
+- Controls remain large tap targets on narrow screens.
+- Board geometry, checker sizes, pip boxes, and dice scale down while preserving gameplay clarity.
+- Primary actions (roll, source select, destination select) remain the same across viewport sizes.


### PR DESCRIPTION
### Motivation

- Provide a concise, code-accurate handoff for another developer/AI to understand and extend the app without changing gameplay logic. 
- Make the frontend-only constraints and persistence strategy explicit so future changes respect the local-only architecture. 
- Surface UI/UX, data shape, and decision rationale to speed up safe UI improvements and targeted feature work.

### Description

- Replaced and expanded the top-level `README.md` with a project overview, key constraints (frontend-only, `localStorage` under `backgammon.save.v1`), run/build instructions (`npm install`, `npm run dev`, `npm run build`, `npm run preview`), a brief folder map, and a how-to-play summary. 
- Added `CONTRIBUTING.md` with local setup instructions, UI-change guardrails (don’t alter `src/game.js` rules helpers), a manual test checklist (rolling, doubles, bar entry, hitting, bearing off, undo, persistence), and lightweight code-style guidance. 
- Added a `docs/` set documenting implementation and handoff details: `ARCHITECTURE.md`, `RULES.md`, `STATE_MACHINE.md`, `UI_GUIDE.md`, `DATA_MODEL.md`, `DECISIONS.md`, and `ROADMAP.md`, each referencing the actual code mapping in `src/App.jsx`, `src/game.js`, and `src/styles.css`. 
- No gameplay logic or rendering behavior was modified; documentation explicitly points to the canonical functions/fields (`computeLegalMoves`, `applyMove`, `rollDice`, `canBearOff`, `STORAGE_KEY`, `SCHEMA_VERSION`) for verification and follow-up.

### Testing

- Built the production bundle with `npm run build` to validate the app compiles and assets render correctly, and the build completed successfully. 
- No unit tests exist in the repo, so the build is the primary automated validation for these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e05107a0832eb334964694fa670c)