### PR TITLE
Preserve opening-roll dice order for first turn

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -459,25 +459,27 @@ export function rollDice(state, forcedValues = null, options = {}) {
   }
 
   if (state.openingRollPending) {
-    const openerA = forcedValues?.[0] ?? rollDie1to6();
-    const openerB = forcedValues?.[1] ?? rollDie1to6();
+    const openingRoll = {
+      player: forcedValues?.[0] ?? rollDie1to6(),
+      computer: forcedValues?.[1] ?? rollDie1to6()
+    };
 
-    if (openerA === openerB) {
+    if (openingRoll.player === openingRoll.computer) {
       return {
         ...cloneState(state),
         dice: { values: [], remaining: [] },
-        statusText: `Opening roll tied at ${openerA}-${openerB}. Roll again.`
+        statusText: `Opening roll tied at ${openingRoll.player}-${openingRoll.computer}. Roll again.`
       };
     }
 
-    const startingPlayer = openerA > openerB ? PLAYER_A : PLAYER_B;
+    const firstTurnDice = [openingRoll.player, openingRoll.computer];
+    const [d1, d2] = firstTurnDice;
+    const startingPlayer = openingRoll.player > openingRoll.computer ? PLAYER_A : PLAYER_B;
     const startText =
       startingPlayer === PLAYER_A
-        ? `You go first with ${openerA} and ${openerB}.`
-        : `Computer goes first with ${openerB} and ${openerA}.`;
+        ? `You go first with ${openingRoll.player} and ${openingRoll.computer}.`
+        : `Computer goes first with ${openingRoll.player} and ${openingRoll.computer}.`;
 
-    const openingValues = startingPlayer === PLAYER_A ? [openerA, openerB] : [openerB, openerA];
-    const [d1, d2] = openingValues;
     const remaining = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2];
 
     return {
@@ -485,7 +487,7 @@ export function rollDice(state, forcedValues = null, options = {}) {
       currentPlayer: startingPlayer,
       openingRollPending: false,
       dice: {
-        values: openingValues,
+        values: firstTurnDice,
         remaining
       },
       statusText: startText


### PR DESCRIPTION
### Motivation

- The opening-roll flow previously reordered the two rolled dice depending on who won, causing the displayed first-turn dice to be reversed from the actual opening roll.
- The first turn must display the exact numbers that were rolled (player then computer) while only using the comparison to decide who moves first.

### Description

- Introduced an `openingRoll` object with explicit `player` and `computer` fields to capture opening values separately (in `rollDice`).
- Seed the first-turn display with `firstTurnDice = [openingRoll.player, openingRoll.computer]` and set `dice.values` to that array without swapping values.
- Determine `currentPlayer` by comparing `openingRoll.player` and `openingRoll.computer` only, leaving dice ordering unchanged, and preserve existing tie behavior.
- Kept the normal roll path unchanged so the standard two-dice generator is not used for the opening-first turn and no opening state is accidentally overwritten.

### Testing

- Ran the production build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57b9c987c832e8aa87c933d92657e)