### PR TITLE
Require player-initiated reroll for tied opening rolls; add explicit opening phase/state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,6 @@ const BOARD_DICE_ROLL_MS = 1000;
 const OPENING_ROLL_DIE_ANIM_MS = BOARD_DICE_ROLL_MS;
 const OPENING_ROLL_DIE_HOLD_MS = 220;
 const OPENING_ROLL_RESULT_MS = 800;
-const OPENING_ROLL_TIE_DELAY_MS = 600;
 const OPENING_ROLL_COMPUTER_START_BEAT_MS = 420;
 const COMPUTER_TURN_DELAY_MS = 1000;
 const DICE_USED_STYLE_DELAY_MS = 250;
@@ -316,12 +315,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
   const [isBoardDiceRolling, setIsBoardDiceRolling] = useState(false);
   const [isAnimatingMove, setIsAnimatingMove] = useState(false);
   const [movingChecker, setMovingChecker] = useState(null);
-  const [openingRoll, setOpeningRoll] = useState({
-    step: 'WAITING_FOR_PLAYER',
-    playerDie: null,
-    computerDie: null,
-    winner: null
-  });
   const [pendingRoll, setPendingRoll] = useState(null);
   const [isAnimatingRoll, setIsAnimatingRoll] = useState(false);
   const [disableUsedDiceStyling, setDisableUsedDiceStyling] = useState(false);
@@ -340,21 +333,19 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
   const suppressNextCommittedRollAnimationRef = useRef(false);
   const openingComputerStartBeatUntilRef = useRef(0);
   const isComputerTurn = game.currentPlayer === PLAYER_B;
-  const gamePhase = game.openingRollPending ? 'OPENING_ROLL' : 'TURN_PLAY';
-  const isOpeningRollSequenceRunning =
-    gamePhase === 'OPENING_ROLL' && (openingRoll.step === 'PLAYER_ROLLING' || openingRoll.step === 'COMPUTER_ROLLING' || openingRoll.step === 'DONE');
+  const gamePhase = game.phase === 'opening' ? 'OPENING_ROLL' : 'TURN_PLAY';
+  const isOpeningRollSequenceRunning = gamePhase === 'OPENING_ROLL' && game.openingRoll.status === 'rolling';
   const isAnyRollAnimationRunning = isBoardDiceRolling || isAnimatingRoll;
   const openingMessage = (() => {
     if (gamePhase !== 'OPENING_ROLL') {
       return game.statusText;
     }
-    if (openingRoll.step === 'PLAYER_ROLLING') return 'Opening roll — highest die goes first. You roll…';
-    if (openingRoll.step === 'COMPUTER_ROLLING') return 'Opening roll — highest die goes first. Computer rolls…';
-    if (openingRoll.step === 'DONE') {
-      if (openingRoll.winner === 'player') return 'Opening roll — highest die goes first. You go first.';
-      if (openingRoll.winner === 'computer') return 'Opening roll — highest die goes first. Computer goes first.';
-      return 'Opening roll — highest die goes first. Tie — roll again.';
+    if (game.openingRoll.status === 'rolling') {
+      return game.openingRoll.computer == null
+        ? 'Opening roll — highest die goes first. You roll…'
+        : 'Opening roll — highest die goes first. Computer rolls…';
     }
+    if (game.openingRoll.status === 'tie') return 'Opening roll — highest die goes first. Tie — roll again.';
     return 'Opening roll — highest die goes first.';
   })();
 
@@ -445,7 +436,7 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
   const canPlayerRoll =
     !game.winner &&
     !isAnyRollAnimationRunning &&
-    ((gamePhase === 'OPENING_ROLL' && openingRoll.step === 'WAITING_FOR_PLAYER') ||
+    ((gamePhase === 'OPENING_ROLL' && ['idle', 'tie'].includes(game.openingRoll.status)) ||
       (gamePhase === 'TURN_PLAY' && game.currentPlayer === PLAYER_A && playerTurnPhase === 'NEED_ROLL'));
 
   useEffect(() => {
@@ -603,7 +594,7 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     setGame((prev) => {
       if (
         prev.currentPlayer !== PLAYER_A ||
-        prev.openingRollPending ||
+        prev.phase === 'opening' ||
         (prev.dice.values.length === 0 && prev.dice.remaining.length === 0) ||
         prev.dice.remaining.length > 0
       ) {
@@ -620,7 +611,7 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
   }, [game, gamePhase, playerTurnPhase]);
 
   useEffect(() => {
-    if (game.winner || game.openingRollPending || !isComputerTurn) {
+    if (game.winner || game.phase === 'opening' || !isComputerTurn) {
       return undefined;
     }
     if (isAnimatingMove || isAnyRollAnimationRunning || computerTurnInFlightRef.current) {
@@ -758,7 +749,10 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     const playerDie = forced?.[0] ?? (rollDie1to6());
     const computerDie = forced?.[1] ?? (rollDie1to6());
 
-    setOpeningRoll({ step: 'PLAYER_ROLLING', playerDie, computerDie: null, winner: null });
+    setGame((prev) => ({
+      ...prev,
+      openingRoll: { player: playerDie, computer: null, status: 'rolling' }
+    }));
     setPendingRoll({ values: [playerDie], animatedMask: [true], owner: 'opening', id: openingRollId });
     setIsAnimatingRoll(true);
     setDiceAnimKey((k) => k + 2);
@@ -769,7 +763,10 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     await wait(OPENING_ROLL_DIE_HOLD_MS);
     if (didCancel()) return;
 
-    setOpeningRoll({ step: 'COMPUTER_ROLLING', playerDie, computerDie, winner: null });
+    setGame((prev) => ({
+      ...prev,
+      openingRoll: { player: playerDie, computer: computerDie, status: 'rolling' }
+    }));
     setPendingRoll({ values: [playerDie, computerDie], animatedMask: [false, true], owner: 'opening', id: openingRollId });
     setIsAnimatingRoll(true);
     setDiceAnimKey((k) => k + 2);
@@ -777,35 +774,22 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     if (didCancel()) return;
     setIsAnimatingRoll(false);
 
-    const winner = playerDie === computerDie ? 'tie' : playerDie > computerDie ? 'player' : 'computer';
-    setOpeningRoll({ step: 'DONE', playerDie, computerDie, winner });
     await wait(OPENING_ROLL_RESULT_MS);
     if (didCancel()) return;
     setPendingRoll((prev) => (prev?.id === openingRollId ? null : prev));
 
-    if (winner === 'tie') {
-      await wait(OPENING_ROLL_TIE_DELAY_MS);
-      if (didCancel()) return;
-      setPendingRoll((prev) => (prev?.id === openingRollId ? null : prev));
-      setOpeningRoll({ step: 'WAITING_FOR_PLAYER', playerDie: null, computerDie: null, winner: null });
-      if (!forced) {
-        void runOpeningRollSequence(null);
-      }
-      return;
-    }
-
-    setOpeningRoll({ step: 'DONE', playerDie, computerDie, winner });
-    suppressNextCommittedRollAnimationRef.current = true;
     setGame((prev) => {
-      if (prev.winner || !prev.openingRollPending || prev.dice.remaining.length > 0) {
+      if (prev.winner || prev.phase !== 'opening' || prev.dice.remaining.length > 0) {
         return prev;
       }
-      return pushUndoState(prev, rollDice(prev, [playerDie, computerDie]));
+      suppressNextCommittedRollAnimationRef.current = true;
+      const rolled = rollDice(prev, [playerDie, computerDie]);
+      if (rolled.phase === 'playing' && rolled.currentPlayer === PLAYER_B) {
+        openingComputerStartBeatUntilRef.current = Date.now() + OPENING_ROLL_COMPUTER_START_BEAT_MS;
+      }
+      return pushUndoState(prev, rolled);
     });
 
-    if (winner === 'computer') {
-      openingComputerStartBeatUntilRef.current = Date.now() + OPENING_ROLL_COMPUTER_START_BEAT_MS;
-    }
     setSelectedSource(null);
   }
 
@@ -833,7 +817,7 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
       await wait(BOARD_DICE_ROLL_MS);
 
       setGame((prev) => {
-        if (prev.winner || prev.currentPlayer !== PLAYER_A || prev.openingRollPending || prev.dice.remaining.length > 0) {
+        if (prev.winner || prev.currentPlayer !== PLAYER_A || prev.phase === 'opening' || prev.dice.remaining.length > 0) {
           return prev;
         }
 
@@ -1034,7 +1018,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     setPendingRoll(null);
     setIsAnimatingRoll(false);
     setToastMessage(null);
-    setOpeningRoll({ step: 'WAITING_FOR_PLAYER', playerDie: null, computerDie: null, winner: null });
     const reset = createInitialState();
     commit(withUndo(reset));
     setSelectedSource(null);
@@ -1051,7 +1034,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     setPendingRoll(null);
     setIsAnimatingRoll(false);
     setToastMessage(null);
-    setOpeningRoll({ step: 'WAITING_FOR_PLAYER', playerDie: null, computerDie: null, winner: null });
     const reset = {
       ...createInitialState(),
       undoStack: game.undoStack,
@@ -1072,7 +1054,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     setPendingRoll(null);
     setIsAnimatingRoll(false);
     setToastMessage(null);
-    setOpeningRoll({ step: 'WAITING_FOR_PLAYER', playerDie: null, computerDie: null, winner: null });
     const previous = undo(game);
     commit(previous);
     setSelectedSource(null);
@@ -1089,7 +1070,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     setPendingRoll(null);
     setIsAnimatingRoll(false);
     setToastMessage(null);
-    setOpeningRoll({ step: 'WAITING_FOR_PLAYER', playerDie: null, computerDie: null, winner: null });
     window.localStorage.removeItem(STORAGE_KEY);
     commit(createInitialState());
     setSelectedSource(null);

--- a/src/game.js
+++ b/src/game.js
@@ -77,9 +77,15 @@ export function createInitialState() {
     bar: { A: 0, B: 0 },
     bearOff: { A: 0, B: 0 },
     currentPlayer: PLAYER_A,
+    phase: 'opening',
     dice: { values: [], remaining: [] },
     winner: null,
     openingRollPending: true,
+    openingRoll: {
+      player: null,
+      computer: null,
+      status: 'idle'
+    },
     undoStack: [],
     statusText: 'Roll to determine who goes first.',
     dev: { debugOpen: false, dieA: 1, dieB: 1 }
@@ -458,7 +464,7 @@ export function rollDice(state, forcedValues = null, options = {}) {
     return state;
   }
 
-  if (state.openingRollPending) {
+  if (state.phase === 'opening' || state.openingRollPending) {
     const openingRoll = {
       player: forcedValues?.[0] ?? rollDie1to6(),
       computer: forcedValues?.[1] ?? rollDie1to6()
@@ -467,7 +473,13 @@ export function rollDice(state, forcedValues = null, options = {}) {
     if (openingRoll.player === openingRoll.computer) {
       return {
         ...cloneState(state),
+        phase: 'opening',
         dice: { values: [], remaining: [] },
+        openingRoll: {
+          player: openingRoll.player,
+          computer: openingRoll.computer,
+          status: 'tie'
+        },
         statusText: `Opening roll tied at ${openingRoll.player}-${openingRoll.computer}. Roll again.`
       };
     }
@@ -485,7 +497,13 @@ export function rollDice(state, forcedValues = null, options = {}) {
     return {
       ...cloneState(state),
       currentPlayer: startingPlayer,
+      phase: 'playing',
       openingRollPending: false,
+      openingRoll: {
+        player: openingRoll.player,
+        computer: openingRoll.computer,
+        status: 'done'
+      },
       dice: {
         values: firstTurnDice,
         remaining
@@ -632,10 +650,20 @@ export function restoreState(raw) {
     }
 
     const base = createInitialState();
+    const normalizedPhase = parsed.phase === 'playing' || parsed.phase === 'opening'
+      ? parsed.phase
+      : (parsed.openingRollPending === false ? 'playing' : 'opening');
+    const parsedOpeningRoll = isPlainObject(parsed.openingRoll) ? parsed.openingRoll : {};
     return {
       ...base,
       ...parsed,
-      openingRollPending: typeof parsed.openingRollPending === 'boolean' ? parsed.openingRollPending : base.openingRollPending,
+      phase: normalizedPhase,
+      openingRollPending: normalizedPhase === 'opening',
+      openingRoll: {
+        player: Number.isInteger(parsedOpeningRoll.player) ? Math.min(6, Math.max(1, parsedOpeningRoll.player)) : null,
+        computer: Number.isInteger(parsedOpeningRoll.computer) ? Math.min(6, Math.max(1, parsedOpeningRoll.computer)) : null,
+        status: ['idle', 'rolling', 'tie', 'done'].includes(parsedOpeningRoll.status) ? parsedOpeningRoll.status : base.openingRoll.status
+      },
       statusText: typeof parsed.statusText === 'string' ? parsed.statusText : base.statusText,
       dev: isPlainObject(parsed.dev)
         ? {


### PR DESCRIPTION
### Motivation
- Opening-roll ties were being auto-rerolled by the computer which produced poor UX; the user should initiate any reroll by clicking `Roll Dice`.
- The app needed an explicit opening phase and structured opening-roll state so UI and game logic can cleanly represent `idle`, `rolling`, `tie`, and `done` states and avoid implicit behavior.

### Description
- Added explicit game phase tracking via `phase: 'opening' | 'playing'` and a structured `openingRoll: { player, computer, status }` to the core state and `createInitialState` in `src/game.js`.
- Updated `rollDice` in `src/game.js` so opening-roll ties set `openingRoll.status = 'tie'`, keep the phase as `opening`, and do not trigger an automatic reroll; non-tied opening rolls transition to `phase = 'playing'` and the opening dice are used as the first-turn dice.
- Reworked the UI and orchestration in `src/App.jsx` to use the new `phase`/`openingRoll` state, to show a tie message (`Tie — roll again.`), to enable the `Roll Dice` button only when `game.openingRoll.status` is `idle` or `tie` during opening, to keep the player-first then computer animation sequence, and to ensure normal turn rolls are blocked while `phase === 'opening'`.
- Added restore-time normalization in `restoreState` to handle legacy saves by deriving `phase`/`openingRoll` from older `openingRollPending` data.

### Testing
- Attempted `npm run build` to validate the production bundle but it failed in this environment due to unresolved local vendor dependencies (`react-helmet-async` / `react-router-dom`).
- Attempted `npm run dev -- --host 0.0.0.0 --port 4173` to run the app locally for interactive verification, but the dev server could not launch because the same vendor dependencies could not be resolved in this environment.
- No automated unit tests were present or executed; the changes were exercised via local code inspection and running the dev/build commands where possible under the environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58007cd38832e8f7194e52f032d0e)