### PR TITLE
Execute only one legal move per click (prevent auto-chaining)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,10 +39,6 @@ function wait(ms) {
   });
 }
 
-function moveMatches(a, b) {
-  return a && b && a.from === b.from && a.to === b.to && a.dieUsed === b.dieUsed;
-}
-
 function pointOwner(value) {
   if (value > 0) return 'A';
   if (value < 0) return 'B';
@@ -380,46 +376,16 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
       return [];
     }
     const sourceMoves = movesBySource.get(sourceKey(activeSelectedSource)) ?? [];
-    if (!sourceMoves.length) {
-      return [];
-    }
-
-    const options = [];
-    const seen = new Set();
-
-    for (const first of sourceMoves) {
-      const singleKey = `${destinationKey(first.to)}|${sourceKey(first.from)}>${destinationKey(first.to)}:${first.dieUsed}`;
-      if (!seen.has(singleKey)) {
-        options.push({ to: first.to, moves: [first] });
-        seen.add(singleKey);
-      }
-
-      const afterFirst = applyMove(game, first);
-      if (afterFirst.currentPlayer !== game.currentPlayer || afterFirst.winner) {
-        continue;
-      }
-
-      const secondMoves = computeLegalMoves(afterFirst).filter((nextMove) => sourceKey(nextMove.from) === sourceKey(first.to));
-      for (const second of secondMoves) {
-        const chainKey = `${destinationKey(second.to)}|${sourceKey(first.from)}>${destinationKey(first.to)}:${first.dieUsed},${sourceKey(second.from)}>${destinationKey(second.to)}:${second.dieUsed}`;
-        if (seen.has(chainKey)) {
-          continue;
-        }
-        options.push({ to: second.to, moves: [first, second] });
-        seen.add(chainKey);
-      }
-    }
-
-    return options;
-  }, [activeSelectedSource, game, movesBySource]);
+    return sourceMoves;
+  }, [activeSelectedSource, movesBySource]);
 
   const destinationSet = useMemo(() => {
     if (isAnyRollAnimationRunning) {
       return new Set();
     }
     const set = new Set();
-    for (const option of moveOptionsForSelected) {
-      set.add(destinationKey(option.to));
+    for (const move of moveOptionsForSelected) {
+      set.add(destinationKey(move.to));
     }
     return set;
   }, [isAnyRollAnimationRunning, moveOptionsForSelected]);
@@ -940,25 +906,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     return next;
   }
 
-  function chooseMoveOptionForDestination(stateAtMove, candidates) {
-    if (candidates.length <= 1) {
-      return candidates[0] ?? null;
-    }
-
-    const maxSteps = Math.max(...candidates.map((c) => c.moves.length));
-    const longest = candidates.filter((c) => c.moves.length === maxSteps);
-    if (longest.length === 1) {
-      return longest[0];
-    }
-
-    if (maxSteps === 1) {
-      const bestSingle = chooseMoveForDestination(stateAtMove, longest.map((c) => c.moves[0]));
-      return longest.find((c) => moveMatches(c.moves[0], bestSingle)) ?? longest[0];
-    }
-
-    return longest[0];
-  }
-
   async function performMoveSequence(stateAtMove, moves) {
     if (isAnimatingMove) {
       return;
@@ -994,17 +941,17 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
       return;
     }
 
-    const candidates = moveOptionsForSelected.filter((option) => destinationKey(option.to) === destinationKey(destination));
+    const candidates = moveOptionsForSelected.filter((move) => destinationKey(move.to) === destinationKey(destination));
     if (!candidates.length) {
       return;
     }
 
-    const chosenOption = chooseMoveOptionForDestination(game, candidates);
-    if (!chosenOption) {
+    const chosenMove = chooseMoveForDestination(game, candidates);
+    if (!chosenMove) {
       return;
     }
 
-    void performMoveSequence(game, chosenOption.moves);
+    void performMoveSequence(game, [chosenMove]);
   }
 
   function handleNewGame() {

--- a/src/__tests__/App.move-selection.test.jsx
+++ b/src/__tests__/App.move-selection.test.jsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import App from '../App.jsx';
+import { PLAYER_A, SCHEMA_VERSION, STORAGE_KEY } from '../game.js';
+
+function buildSingleClickScenario() {
+  const points = Array(24).fill(0);
+  // Point 2 and point 1 for player A.
+  points[1] = 1;
+  points[0] = 1;
+
+  return {
+    version: SCHEMA_VERSION,
+    points,
+    bar: { A: 0, B: 0 },
+    bearOff: { A: 0, B: 0 },
+    currentPlayer: PLAYER_A,
+    phase: 'playing',
+    dice: { values: [6, 1], remaining: [6, 1] },
+    winner: null,
+    openingRollPending: false,
+    openingRoll: { player: 6, computer: 1, status: 'done' },
+    undoStack: [],
+    statusText: 'Player rolled 6 and 1.',
+    dev: { debugOpen: false, dieA: 1, dieB: 1 }
+  };
+}
+
+describe('App move selection', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildSingleClickScenario()));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => ({
+        matches: true,
+        media: '',
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false
+      })
+    });
+  });
+
+  it('uses one die per click and keeps the turn active when legal moves remain', async () => {
+    const user = userEvent.setup();
+    render(<App showSeo={false} showHeader={false} />);
+
+    const pointTwo = screen.getByRole('button', { name: 'Point 2' });
+    const playerBearOff = screen.getByRole('button', { name: 'Player bear off' });
+
+    await user.click(pointTwo);
+    await user.click(playerBearOff);
+
+    await waitFor(() => {
+      expect(playerBearOff).toHaveTextContent('1');
+    });
+
+    const pointOne = screen.getByRole('button', { name: 'Point 1' });
+    expect(pointOne).toHaveClass('movable-source');
+    expect(playerBearOff).not.toHaveTextContent('2');
+    expect(screen.getByRole('button', { name: 'Roll Dice' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Players should decide each die/move separately; a single click must perform exactly one legal move (one die) instead of auto-selecting a chained second move.
- Destination highlights and source movability must reflect only immediate legal moves to avoid hiding a second independent decision from the player.

### Description
- Changed `moveOptionsForSelected` in `src/App.jsx` to return only immediate legal moves from `movesBySource` and removed the logic that synthesized two-step chains via `applyMove` and `computeLegalMoves`.
- Updated destination highlighting to derive from immediate moves (`moveOptionsForSelected` now contains single-move objects) by iterating `move.to` directly when building `destinationSet`.
- Replaced the multi-step chooser with selection among immediate moves only: `moveToDestination` now filters immediate `move` candidates, calls `chooseMoveForDestination(game, candidates)` as a tie-breaker, and invokes `performMoveSequence(game, [chosenMove])` (single-move array).
- Added a component-level regression test `src/__tests__/App.move-selection.test.jsx` that sets up the bearing-off scenario (A has checkers on points 2 and 1 with dice `6` and `1`) and asserts one click consumes a single die and leaves the remaining move selectable.

### Testing
- Ran an inline Node check using `computeLegalMoves` and `applyMove` to validate that after bearing off point 2 with die `6`, the game remains on player A with die `1` still playable from point 1 (succeeded).
- Added a UI component test `src/__tests__/App.move-selection.test.jsx` to assert one-click-per-die behavior (test file created but not executed in this environment).
- Attempted `npm run build` and `npx vitest` in the sandbox but test/build runs failed due to external registry/package access (`react-helmet-async` resolution and `vitest` install blocked by registry policy), so the component test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6059ffbd4832ea5ad9ba1e41d92a2)