### PR TITLE
Add chain destination options for selected checker

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -379,16 +379,52 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     return sourceMoves;
   }, [activeSelectedSource, movesBySource]);
 
+  const chainOptionsForSelected = useMemo(() => {
+    if (activeSelectedSource == null) {
+      return [];
+    }
+
+    const options = [];
+    for (const firstMove of moveOptionsForSelected) {
+      const afterFirst = applyMove(game, firstMove);
+      if (afterFirst.currentPlayer !== game.currentPlayer || afterFirst.winner) {
+        continue;
+      }
+
+      const secondMoves = computeLegalMoves(afterFirst);
+      for (const secondMove of secondMoves) {
+        if (destinationKey(secondMove.from) !== destinationKey(firstMove.to)) {
+          continue;
+        }
+        options.push({
+          to: secondMove.to,
+          moves: [firstMove, secondMove],
+          kind: 'chain'
+        });
+      }
+    }
+
+    return options;
+  }, [activeSelectedSource, game, moveOptionsForSelected]);
+
+  const destinationOptionsForSelected = useMemo(
+    () => [
+      ...moveOptionsForSelected.map((move) => ({ to: move.to, moves: [move], kind: 'single' })),
+      ...chainOptionsForSelected
+    ],
+    [moveOptionsForSelected, chainOptionsForSelected]
+  );
+
   const destinationSet = useMemo(() => {
     if (isAnyRollAnimationRunning) {
       return new Set();
     }
     const set = new Set();
-    for (const move of moveOptionsForSelected) {
-      set.add(destinationKey(move.to));
+    for (const option of destinationOptionsForSelected) {
+      set.add(destinationKey(option.to));
     }
     return set;
-  }, [isAnyRollAnimationRunning, moveOptionsForSelected]);
+  }, [destinationOptionsForSelected, isAnyRollAnimationRunning]);
 
   const movableSourceSet = useMemo(() => {
     const set = new Set();
@@ -941,17 +977,41 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
       return;
     }
 
-    const candidates = moveOptionsForSelected.filter((move) => destinationKey(move.to) === destinationKey(destination));
-    if (!candidates.length) {
+    const destinationId = destinationKey(destination);
+    const singleCandidates = destinationOptionsForSelected.filter(
+      (option) => option.kind === 'single' && destinationKey(option.to) === destinationId
+    );
+    const chainCandidates = destinationOptionsForSelected.filter(
+      (option) => option.kind === 'chain' && destinationKey(option.to) === destinationId
+    );
+
+    if (!singleCandidates.length && !chainCandidates.length) {
       return;
     }
 
-    const chosenMove = chooseMoveForDestination(game, candidates);
-    if (!chosenMove) {
+    let chosenOption = null;
+    if (!singleCandidates.length && chainCandidates.length) {
+      const preferredFirstMove = chooseMoveForDestination(
+        game,
+        chainCandidates.map((option) => option.moves[0])
+      );
+      chosenOption =
+        chainCandidates.find((option) => option.moves[0] === preferredFirstMove) ?? chainCandidates[0];
+    } else if (singleCandidates.length) {
+      const chosenMove = chooseMoveForDestination(
+        game,
+        singleCandidates.map((option) => option.moves[0])
+      );
+      chosenOption = singleCandidates.find((option) => option.moves[0] === chosenMove) ?? singleCandidates[0];
+    } else {
+      chosenOption = chainCandidates[0];
+    }
+
+    if (!chosenOption) {
       return;
     }
 
-    void performMoveSequence(game, [chosenMove]);
+    void performMoveSequence(game, chosenOption.moves);
   }
 
   function handleNewGame() {


### PR DESCRIPTION
### Motivation
- Allow the UI to present legal two-step (chain) destinations for a selected source while keeping immediate single-die moves unchanged.
- Make it possible for the user to explicitly click a destination that represents a two-move sequence and have the app execute that sequence deterministically.

### Description
- Preserve `moveOptionsForSelected` as immediate moves sourced from `movesBySource` and add `chainOptionsForSelected` which computes two-step sequences by applying each `firstMove`, computing `computeLegalMoves` on the resulting state, and keeping `secondMove` entries that originate from `firstMove.to`.
- Combine single and chain entries into `destinationOptionsForSelected` and update `destinationSet` to reflect the union of available clickable destinations.
- Update `moveToDestination(destination)` to gather `singleCandidates` and `chainCandidates`, choose an explicit `chosenOption` (using `chooseMoveForDestination` to disambiguate first moves), and execute the chosen sequence via `performMoveSequence(game, chosenOption.moves)`.
- Preserve the safety invariant by not performing any automatic follow-up move unless the user explicitly clicks a chain destination and by preferring single-move behavior unless chain-only or unambiguous.

### Testing
- Ran `npm run build` which initially failed due to missing vendor packages and then succeeded after running `npm install` (build completed with Vite and produced `dist/`).
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which started successfully and served the app.
- Used an automated Playwright script to load the running app and capture a screenshot to visually verify the updated destination highlighting and behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a619b4710c832eb69ccea800e9c145)