### PR TITLE
Add chain-click move-selection tests and extract move-sequence helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,6 +18,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.2",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^2.1.8",
+    "jsdom": "^25.0.1",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import {
 } from './game.js';
 import SEO from './components/SEO.jsx';
 import { rollDie1to6 } from './random.js';
+import { buildPathForMove, performMoveSequence as runMoveSequence } from './moveSequence.js';
 
 const TOP_LEFT = [12, 13, 14, 15, 16, 17];
 const TOP_RIGHT = [18, 19, 20, 21, 22, 23];
@@ -876,39 +877,9 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     return pointRefs.current.get(location) ?? null;
   }
 
-  function pathForMove(stateAtMove, move) {
-    const path = [move.from];
-    const player = stateAtMove.currentPlayer;
-
-    if (typeof move.from === 'number' && typeof move.to === 'number') {
-      const dir = move.to > move.from ? 1 : -1;
-      for (let p = move.from + dir; p !== move.to + dir; p += dir) {
-        path.push(p);
-      }
-      return path;
-    }
-
-    if (typeof move.from === 'number' && move.to === 'off') {
-      const dir = player === PLAYER_A ? -1 : 1;
-      for (let step = 1; step <= move.dieUsed; step += 1) {
-        const point = move.from + dir * step;
-        if (point < 0 || point > 23) {
-          path.push('off');
-          return path;
-        }
-        path.push(point);
-      }
-      path.push('off');
-      return path;
-    }
-
-    path.push(move.to);
-    return path;
-  }
-
   async function animateSingleMove(stateAtMove, move) {
     const player = stateAtMove.currentPlayer;
-    const path = pathForMove(stateAtMove, move);
+    const path = buildPathForMove(stateAtMove, move);
     const centers = path
       .map((location) => {
         const element = elementForLocation(location, player);
@@ -927,17 +898,6 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
       await wait(MOVE_STEP_MS);
     }
     await wait(30);
-  }
-
-  function applyMoveSequence(stateAtMove, moves) {
-    let next = stateAtMove;
-    for (const move of moves) {
-      next = applyMove(next, move);
-      if (next.currentPlayer !== stateAtMove.currentPlayer || next.winner) {
-        break;
-      }
-    }
-    return next;
   }
 
   function chooseMoveOptionForDestination(stateAtMove, candidates) {
@@ -967,26 +927,21 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     setIsAnimatingMove(true);
     try {
-      if (!prefersReducedMotion) {
-        let animationState = stateAtMove;
-        for (const move of moves) {
-          await animateSingleMove(animationState, move);
-          animationState = applyMove(animationState, move);
-          if (animationState.currentPlayer !== stateAtMove.currentPlayer || animationState.winner) {
-            break;
-          }
+      const next = await runMoveSequence(stateAtMove, moves, {
+        prefersReducedMotion,
+        animateSingleMove,
+        applyMoveFn: applyMove
+      });
+      setGame((prev) => {
+        if (prev !== stateAtMove) {
+          return prev;
         }
-      }
+        return pushUndoState(prev, next);
+      });
     } finally {
       setMovingChecker(null);
       setIsAnimatingMove(false);
     }
-    setGame((prev) => {
-      if (prev !== stateAtMove) {
-        return prev;
-      }
-      return pushUndoState(prev, applyMoveSequence(prev, moves));
-    });
   }
 
   function moveToDestination(destination) {

--- a/src/__tests__/App.move-selection.test.jsx
+++ b/src/__tests__/App.move-selection.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from '../App.jsx';
+import { PLAYER_A, STORAGE_KEY, createInitialState, serializeState } from '../game.js';
+import { buildPathForMove, performMoveSequence } from '../moveSequence.js';
+
+function seedGame(partial) {
+  const state = {
+    ...createInitialState(),
+    phase: 'playing',
+    openingRollPending: false,
+    openingRoll: { player: 6, computer: 1, status: 'done' },
+    currentPlayer: PLAYER_A,
+    dice: { values: [5, 6], remaining: [5, 6] },
+    points: Array(24).fill(0),
+    bar: { A: 0, B: 0 },
+    bearOff: { A: 0, B: 0 },
+    undoStack: [],
+    statusText: 'Player to move.',
+    ...partial
+  };
+  window.localStorage.setItem(STORAGE_KEY, serializeState(state));
+  return state;
+}
+
+describe('App move selection', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    }));
+  });
+
+  it('single-step destination consumes one die and leaves remainder for player choice', async () => {
+    seedGame({ points: Object.assign(Array(24).fill(0), { 20: 2, 15: -2 }) });
+    render(<App showSeo={false} showHeader={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Point 21' }));
+    const fiveDest = screen.getByRole('button', { name: 'Point 16' });
+    const sixDest = screen.getByRole('button', { name: 'Point 15' });
+    expect(fiveDest.className).toContain('is-legal');
+    expect(sixDest.className).toContain('is-legal');
+
+    await userEvent.click(sixDest);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Point 15' }));
+    expect(screen.getByRole('button', { name: 'Point 10' }).className).toContain('is-legal');
+  });
+
+  it('supports chain-click destination (+11) and consumes both dice in sequence', async () => {
+    seedGame({ points: Object.assign(Array(24).fill(0), { 20: 1, 15: 1, 14: 1, 9: -2, 0: -2 }) });
+    render(<App showSeo={false} showHeader={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Point 21' }));
+
+    const chainedDestination = screen.getByRole('button', { name: 'Point 10' });
+    expect(chainedDestination.className).toContain('is-legal');
+
+    await userEvent.click(chainedDestination);
+
+    await waitFor(() => {
+      const point10 = screen.getByRole('button', { name: 'Point 10' });
+      expect(point10.querySelector('.checker-a')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Point 21' }).querySelector('.checker-a')).toBeFalsy();
+    });
+
+    expect(screen.getByText('Computer to move. Roll dice.')).toBeTruthy();
+  });
+});
+
+describe('move sequence helpers', () => {
+  it('buildPathForMove + performMoveSequence run firstMove then secondMove in order', async () => {
+    const start = seedGame({ points: Object.assign(Array(24).fill(0), { 20: 1, 15: 1, 14: 1, 9: -2 }), dice: { values: [5, 6], remaining: [5, 6] } });
+    const firstMove = { from: 20, to: 15, dieUsed: 5, hit: false };
+    const secondMove = { from: 15, to: 9, dieUsed: 6, hit: false };
+    const animateSpy = vi.fn(async () => {});
+    const applySpy = vi.fn((state, move) => ({ ...state, applied: [...(state.applied ?? []), move], dice: { ...state.dice, remaining: state.dice.remaining.slice(1) } }));
+
+    expect(buildPathForMove(start, firstMove)).toEqual([20, 19, 18, 17, 16, 15]);
+
+    const end = await performMoveSequence(start, [firstMove, secondMove], {
+      prefersReducedMotion: false,
+      animateSingleMove: animateSpy,
+      applyMoveFn: applySpy
+    });
+
+    expect(animateSpy.mock.calls.map((call) => call[1])).toEqual([firstMove, secondMove]);
+    expect(applySpy.mock.calls.map((call) => call[1])).toEqual([firstMove, secondMove, firstMove, secondMove]);
+    expect(end.applied).toEqual([firstMove, secondMove]);
+  });
+
+  it('immediate destination click executes only chosenMove and never implicit second move', async () => {
+    const start = seedGame({ points: Object.assign(Array(24).fill(0), { 20: 1, 14: 1, 9: -2 }), dice: { values: [5, 6], remaining: [5, 6] } });
+    const chosenMove = { from: 20, to: 14, dieUsed: 6, hit: false };
+    const applySpy = vi.fn((state, move) => ({ ...state, applied: [...(state.applied ?? []), move], currentPlayer: PLAYER_A }));
+
+    const result = await performMoveSequence(start, [chosenMove], {
+      prefersReducedMotion: true,
+      applyMoveFn: applySpy
+    });
+
+    expect(applySpy).toHaveBeenCalledTimes(1);
+    expect(applySpy).toHaveBeenCalledWith(start, chosenMove);
+    expect(result.applied).toEqual([chosenMove]);
+  });
+});

--- a/src/moveSequence.js
+++ b/src/moveSequence.js
@@ -1,0 +1,63 @@
+import { applyMove, PLAYER_A } from './game.js';
+
+export function buildPathForMove(stateAtMove, move) {
+  const path = [move.from];
+  const player = stateAtMove.currentPlayer;
+
+  if (typeof move.from === 'number' && typeof move.to === 'number') {
+    const dir = move.to > move.from ? 1 : -1;
+    for (let p = move.from + dir; p !== move.to + dir; p += dir) {
+      path.push(p);
+    }
+    return path;
+  }
+
+  if (typeof move.from === 'number' && move.to === 'off') {
+    const dir = player === PLAYER_A ? -1 : 1;
+    for (let step = 1; step <= move.dieUsed; step += 1) {
+      const point = move.from + dir * step;
+      if (point < 0 || point > 23) {
+        path.push('off');
+        return path;
+      }
+      path.push(point);
+    }
+    path.push('off');
+    return path;
+  }
+
+  path.push(move.to);
+  return path;
+}
+
+export function applyMoveSequence(stateAtMove, moves, applyMoveFn = applyMove) {
+  let next = stateAtMove;
+  for (const move of moves) {
+    next = applyMoveFn(next, move);
+    if (next.currentPlayer !== stateAtMove.currentPlayer || next.winner) {
+      break;
+    }
+  }
+  return next;
+}
+
+export async function performMoveSequence(stateAtMove, moves, options = {}) {
+  const {
+    prefersReducedMotion = false,
+    animateSingleMove = async () => {},
+    applyMoveFn = applyMove
+  } = options;
+
+  if (!prefersReducedMotion) {
+    let animationState = stateAtMove;
+    for (const move of moves) {
+      await animateSingleMove(animationState, move);
+      animationState = applyMoveFn(animationState, move);
+      if (animationState.currentPlayer !== stateAtMove.currentPlayer || animationState.winner) {
+        break;
+      }
+    }
+  }
+
+  return applyMoveSequence(stateAtMove, moves, applyMoveFn);
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true
+  }
 });


### PR DESCRIPTION
### Motivation
- Make chain-click move selection (e.g. a +11 destination consuming two dice) testable and prevent regressions where an immediate destination accidentally triggers an implicit second move. 
- Factor path-building and ordered move execution out of the UI so animation/order behavior can be unit-tested without rendering animation internals. 

### Description
- Add `src/moveSequence.js` with `buildPathForMove`, `applyMoveSequence`, and `performMoveSequence` to centralize path construction and ordered sequence application. 
- Update `src/App.jsx` to use the new helpers for path building and to delegate sequence execution to the shared `performMoveSequence` variant while preserving existing UI guards and animation flow. 
- Add tests in `src/__tests__/App.move-selection.test.jsx` covering: single-step safeguard (one die consumed, remaining move left to player), chain-click destination highlighted/clickable and applying both dice to the chained endpoint, verification that sequence processing runs `firstMove` then `secondMove` in order via spies, and regression assertion that an immediate destination click only executes the chosen single move. 
- Add test tooling/config: `vitest` scripts in `package.json` and test environment config in `vite.config.js` to run tests under `jsdom`.

### Testing
- Added unit tests at `src/__tests__/App.move-selection.test.jsx` but could not run the test suite in this environment because `npm install` failed with `403 Forbidden` when fetching dev dependencies from the npm registry. 
- `npm run build` was attempted and fails in this container due to unresolved local dependency resolution for `react-helmet-async` (pre-existing workspace config), so build validation did not complete. 
- The new helpers were exercised by the test code (spies/assertions) locally in the change, but automated `vitest` execution was not run due to the dependency/install issues above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6162193f0832ea7aad2568fb736fc)