### PR TITLE
Expand move-selection tests for chain-click behavior and animation order

### DIFF
--- a/src/__tests__/App.move-selection.test.jsx
+++ b/src/__tests__/App.move-selection.test.jsx
@@ -1,13 +1,29 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/vitest';
 import App from '../App.jsx';
+import * as gameModule from '../game.js';
 import { PLAYER_A, SCHEMA_VERSION, STORAGE_KEY } from '../game.js';
+
+function setMatchMedia(prefersReducedMotion) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: () => ({
+      matches: prefersReducedMotion,
+      media: '',
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    })
+  });
+}
 
 function buildSingleClickScenario() {
   const points = Array(24).fill(0);
-  // Point 2 and point 1 for player A.
   points[1] = 1;
   points[0] = 1;
 
@@ -28,27 +44,40 @@ function buildSingleClickScenario() {
   };
 }
 
+function buildChainClickScenario() {
+  const points = Array(24).fill(0);
+  // Source checker at point 13. Immediate moves: point 8 (+5), point 7 (+6). Chain destination: point 2 (+11).
+  points[12] = 1;
+
+  return {
+    version: SCHEMA_VERSION,
+    points,
+    bar: { A: 0, B: 0 },
+    bearOff: { A: 0, B: 0 },
+    currentPlayer: PLAYER_A,
+    phase: 'playing',
+    dice: { values: [5, 6], remaining: [5, 6] },
+    winner: null,
+    openingRollPending: false,
+    openingRoll: { player: 6, computer: 1, status: 'done' },
+    undoStack: [],
+    statusText: 'Player rolled 5 and 6.',
+    dev: { debugOpen: false, dieA: 1, dieB: 1 }
+  };
+}
+
+function seedState(state) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
 describe('App move selection', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildSingleClickScenario()));
-
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: () => ({
-        matches: true,
-        media: '',
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false
-      })
-    });
+    setMatchMedia(true);
   });
 
   it('uses one die per click and keeps the turn active when legal moves remain', async () => {
+    seedState(buildSingleClickScenario());
     const user = userEvent.setup();
     render(<App showSeo={false} showHeader={false} />);
 
@@ -66,5 +95,82 @@ describe('App move selection', () => {
     expect(pointOne).toHaveClass('movable-source');
     expect(playerBearOff).not.toHaveTextContent('2');
     expect(screen.getByRole('button', { name: 'Roll Dice' })).toBeDisabled();
+  });
+
+  it('clicking immediate destination runs only the chosen single move', async () => {
+    seedState(buildSingleClickScenario());
+    const applyMoveSpy = vi.spyOn(gameModule, 'applyMove');
+    const user = userEvent.setup();
+    render(<App showSeo={false} showHeader={false} />);
+
+    await user.click(screen.getByRole('button', { name: 'Point 2' }));
+    await user.click(screen.getByRole('button', { name: 'Player bear off' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Player bear off' })).toHaveTextContent('1');
+    });
+
+    expect(applyMoveSpy).toHaveBeenCalledTimes(1);
+    expect(applyMoveSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ from: 1, to: 'off', dieUsed: 6 })
+    );
+
+    applyMoveSpy.mockRestore();
+  });
+
+  it('highlights chained +11 destination and applies both dice in order on click', async () => {
+    seedState(buildChainClickScenario());
+    const applyMoveSpy = vi.spyOn(gameModule, 'applyMove');
+    const user = userEvent.setup();
+    render(<App showSeo={false} showHeader={false} />);
+
+    const source = screen.getByRole('button', { name: 'Point 13' });
+    const plusFive = screen.getByRole('button', { name: 'Point 8' });
+    const plusSix = screen.getByRole('button', { name: 'Point 7' });
+    const plusEleven = screen.getByRole('button', { name: 'Point 2' });
+
+    await user.click(source);
+
+    expect(plusFive).toHaveClass('legal');
+    expect(plusSix).toHaveClass('legal');
+    expect(plusEleven).toHaveClass('legal');
+
+    await user.click(plusEleven);
+
+    await waitFor(() => {
+      expect(source.querySelectorAll('.checker-a')).toHaveLength(0);
+      expect(plusEleven.querySelectorAll('.checker-a')).toHaveLength(1);
+    });
+
+    expect(applyMoveSpy).toHaveBeenCalledTimes(2);
+    expect(applyMoveSpy.mock.calls[0][1]).toMatchObject({ from: 12, to: 7, dieUsed: 5 });
+    expect(applyMoveSpy.mock.calls[1][1]).toMatchObject({ from: 7, to: 1, dieUsed: 6 });
+
+    // Both dice are consumed for this chain click, so the player can no longer move this turn.
+    expect(screen.getByRole('button', { name: 'Roll Dice' })).toBeDisabled();
+
+    applyMoveSpy.mockRestore();
+  });
+
+  it('performMoveSequence animates chained moves in order (first move, then second move)', async () => {
+    vi.useFakeTimers();
+    setMatchMedia(false);
+    seedState(buildChainClickScenario());
+    const applyMoveSpy = vi.spyOn(gameModule, 'applyMove');
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<App showSeo={false} showHeader={false} />);
+
+    await user.click(screen.getByRole('button', { name: 'Point 13' }));
+    await user.click(screen.getByRole('button', { name: 'Point 2' }));
+
+    await vi.runAllTimersAsync();
+
+    expect(applyMoveSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(applyMoveSpy.mock.calls[0][1]).toMatchObject({ from: 12, to: 7, dieUsed: 5 });
+    expect(applyMoveSpy.mock.calls[1][1]).toMatchObject({ from: 7, to: 1, dieUsed: 6 });
+
+    applyMoveSpy.mockRestore();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
### Motivation

- Add coverage for the existing safeguard that a single immediate-destination click consumes only one die and leaves remaining legal moves available. 
- Add tests to exercise the new chain-click flow where a source offers immediate `+5`, `+6` and a chained `+11` endpoint so clicking the chained endpoint consumes both dice. 
- Verify animation sequencing so chained moves are processed in order (first move then second move) rather than teleporting the checker.

### Description

- Rewrote `src/__tests__/App.move-selection.test.jsx` to include helpers `setMatchMedia`, `seedState`, and a new `buildChainClickScenario` to set up deterministic board/dice states. 
- Added `vitest` import usage (`vi`) and a spy on game functions by importing `* as gameModule from '../game.js'` to assert calls to `applyMove`. 
- Added tests: a) original single-click safeguard, b) assertion that clicking an immediate destination runs only the chosen single move (one `applyMove` call), c) chain-click test that highlights `+11`, clicks it, asserts both `applyMove` calls and final checker placement, and d) reduced-motion-off fake-timers test that confirms `performMoveSequence` processes the two moves in order. 
- Tests assert UI state (highlighting classes and button labels), call ordering (`applyMove` mock calls and payload), and that dice/turn state reflects consumed dice after a chain click.

### Testing

- Attempted to run tests with `npm test -- src/__tests__/App.move-selection.test.jsx`, which failed because `package.json` contains no `test` script. 
- Attempted to run `npx vitest run src/__tests__/App.move-selection.test.jsx`, which failed in this environment due to registry access / package fetch restrictions (vitest unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61b22e418832e813239d544c00384)