### PR TITLE
Fix chained checker destination highlighting when doubles are rolled

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -385,22 +385,35 @@ export default function App({ showSeo = true, seoPath = "/play", seoTitle = "Pla
     }
 
     const options = [];
+    const canContinueTurn = (nextState) => nextState.currentPlayer === game.currentPlayer && !nextState.winner;
+
     for (const firstMove of moveOptionsForSelected) {
       const afterFirst = applyMove(game, firstMove);
-      if (afterFirst.currentPlayer !== game.currentPlayer || afterFirst.winner) {
+      if (!canContinueTurn(afterFirst)) {
         continue;
       }
 
-      const secondMoves = computeLegalMoves(afterFirst);
-      for (const secondMove of secondMoves) {
-        if (destinationKey(secondMove.from) !== destinationKey(firstMove.to)) {
+      const stack = [{ state: afterFirst, sequence: [firstMove] }];
+      while (stack.length > 0) {
+        const current = stack.pop();
+        if (!current) {
           continue;
         }
-        options.push({
-          to: secondMove.to,
-          moves: [firstMove, secondMove],
-          kind: 'chain'
-        });
+
+        const lastMove = current.sequence[current.sequence.length - 1];
+        const nextMoves = computeLegalMoves(current.state).filter(
+          (nextMove) => destinationKey(nextMove.from) === destinationKey(lastMove.to)
+        );
+
+        for (const nextMove of nextMoves) {
+          const nextSequence = [...current.sequence, nextMove];
+          options.push({ to: nextMove.to, moves: nextSequence, kind: 'chain' });
+
+          const afterNext = applyMove(current.state, nextMove);
+          if (canContinueTurn(afterNext)) {
+            stack.push({ state: afterNext, sequence: nextSequence });
+          }
+        }
       }
     }
 

--- a/src/__tests__/App.move-selection.test.jsx
+++ b/src/__tests__/App.move-selection.test.jsx
@@ -66,6 +66,28 @@ function buildChainClickScenario() {
   };
 }
 
+function buildDoubleOnesChainScenario() {
+  const points = Array(24).fill(0);
+  // Source checker at point 8. With 1-1-1-1 it can continue to points 7, 6, 5, and 4.
+  points[7] = 1;
+
+  return {
+    version: SCHEMA_VERSION,
+    points,
+    bar: { A: 0, B: 0 },
+    bearOff: { A: 0, B: 0 },
+    currentPlayer: PLAYER_A,
+    phase: 'playing',
+    dice: { values: [1, 1], remaining: [1, 1, 1, 1] },
+    winner: null,
+    openingRollPending: false,
+    openingRoll: { player: 6, computer: 1, status: 'done' },
+    undoStack: [],
+    statusText: 'Player rolled 1 and 1.',
+    dev: { debugOpen: false, dieA: 1, dieB: 1 }
+  };
+}
+
 function seedState(state) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
@@ -172,5 +194,42 @@ describe('App move selection', () => {
 
     applyMoveSpy.mockRestore();
     vi.useRealTimers();
+  });
+
+  it('highlights deep chained destinations for doubles and applies all chained moves on click', async () => {
+    seedState(buildDoubleOnesChainScenario());
+    const applyMoveSpy = vi.spyOn(gameModule, 'applyMove');
+    const user = userEvent.setup();
+    render(<App showSeo={false} showHeader={false} />);
+
+    const source = screen.getByRole('button', { name: 'Point 8' });
+    const plusOne = screen.getByRole('button', { name: 'Point 7' });
+    const plusTwo = screen.getByRole('button', { name: 'Point 6' });
+    const plusThree = screen.getByRole('button', { name: 'Point 5' });
+    const plusFour = screen.getByRole('button', { name: 'Point 4' });
+
+    await user.click(source);
+
+    expect(plusOne).toHaveClass('legal');
+    expect(plusTwo).toHaveClass('legal');
+    expect(plusThree).toHaveClass('legal');
+    expect(plusFour).toHaveClass('legal');
+
+    await user.click(plusFour);
+
+    await waitFor(() => {
+      expect(source.querySelectorAll('.checker-a')).toHaveLength(0);
+      expect(plusFour.querySelectorAll('.checker-a')).toHaveLength(1);
+    });
+
+    expect(applyMoveSpy).toHaveBeenCalledTimes(4);
+    expect(applyMoveSpy.mock.calls.map((call) => call[1])).toEqual([
+      expect.objectContaining({ from: 7, to: 6, dieUsed: 1 }),
+      expect.objectContaining({ from: 6, to: 5, dieUsed: 1 }),
+      expect.objectContaining({ from: 5, to: 4, dieUsed: 1 }),
+      expect.objectContaining({ from: 4, to: 3, dieUsed: 1 })
+    ]);
+
+    applyMoveSpy.mockRestore();
   });
 });


### PR DESCRIPTION
### Motivation

- The UI only surfaced one extra hop for chain destinations, so when doubles are rolled (e.g. `1-1-1-1`) the player could not see deeper reachable destinations like `+3`/`+4` even when legal.

### Description

- Replace the two-ply chain exploration in `chainOptionsForSelected` with a recursive/stack-based search that builds full move sequences while the turn remains with the same player, in `src/App.jsx`.
- Add a `canContinueTurn` helper to ensure sequences are extended only when the next state still belongs to the active player and the game is not won.
- Emit chain options for every reachable follow-up move (each option contains the full `moves` sequence and `to` destination) so the UI highlights deeper destinations for doubles.
- Add a regression test `buildDoubleOnesChainScenario` and a new test in `src/__tests__/App.move-selection.test.jsx` that verifies deep chained destinations are highlighted and that clicking the farthest destination applies all chained moves in order.

### Testing

- Built the application with `npm run build`, which completed successfully.
- Unit test run via `npx vitest run src/__tests__/App.move-selection.test.jsx` could not be executed in this environment due to npm registry/network policy (`403 Forbidden`).
- Executed an automated headless browser check that seeded a doubles state, selected the checker and captured a screenshot proving deep-chain highlighting; the script produced the artifact `artifacts/doubles-chain-highlight.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fad05230832e98e1327ff6e23105)