### PR TITLE
Refactor AI move scoring to support strategy profiles

### DIFF
--- a/src/game/__tests__/ai.test.js
+++ b/src/game/__tests__/ai.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { AI_STRATEGY_PROFILES, chooseComputerMove } from '../ai.js';
+import { PLAYER_A, SCHEMA_VERSION } from '../constants.js';
+
+function createBaseState(remainingDice = [3, 1]) {
+  return {
+    version: SCHEMA_VERSION,
+    points: Array(24).fill(0),
+    bar: { A: 0, B: 0 },
+    bearOff: { A: 0, B: 0 },
+    currentPlayer: PLAYER_A,
+    phase: 'playing',
+    dice: { values: [...remainingDice], remaining: [...remainingDice] },
+    winner: null,
+    openingRollPending: false,
+    openingRoll: { player: 6, computer: 1, status: 'done' },
+    undoStack: [],
+    statusText: 'fixture',
+    dev: { debugOpen: false, dieA: 1, dieB: 1 }
+  };
+}
+
+function moveKey(move) {
+  return `${move.from}->${move.to}|${move.dieUsed}|${move.hit}`;
+}
+
+describe('chooseComputerMove strategy profiles', () => {
+  it('keeps the balanced profile as the default strategy', () => {
+    const state = createBaseState();
+    state.points[5] = 1;
+    state.points[4] = 1;
+    state.points[2] = -1;
+
+    const legalMoves = [
+      { from: 5, to: 2, dieUsed: 3, hit: true },
+      { from: 4, to: 1, dieUsed: 3, hit: false },
+      { from: 5, to: 4, dieUsed: 1, hit: false }
+    ];
+
+    const defaultMove = chooseComputerMove(state, legalMoves);
+    const balancedMove = chooseComputerMove(state, legalMoves, 'balanced');
+
+    expect(moveKey(defaultMove)).toBe(moveKey(balancedMove));
+  });
+
+  it('matches pre-refactor move choices when using default strategy profile', () => {
+    const fixtures = [
+      {
+        state: (() => {
+          const state = createBaseState([3, 1]);
+          state.points[5] = 1;
+          state.points[4] = 1;
+          state.points[2] = -1;
+          return state;
+        })(),
+        legalMoves: [
+          { from: 5, to: 2, dieUsed: 3, hit: true },
+          { from: 4, to: 1, dieUsed: 3, hit: false },
+          { from: 5, to: 4, dieUsed: 1, hit: false }
+        ],
+        expectedMoveKey: '5->2|3|true'
+      },
+      {
+        state: (() => {
+          const state = createBaseState([6, 1]);
+          state.points[1] = 1;
+          state.points[0] = 1;
+          return state;
+        })(),
+        legalMoves: [
+          { from: 1, to: 'off', dieUsed: 6, hit: false },
+          { from: 1, to: 0, dieUsed: 1, hit: false },
+          { from: 0, to: 'off', dieUsed: 1, hit: false }
+        ],
+        expectedMoveKey: '1->off|6|false'
+      },
+      {
+        state: (() => {
+          const state = createBaseState([4, 2]);
+          state.points[10] = 2;
+          state.points[6] = 1;
+          state.points[8] = -1;
+          return state;
+        })(),
+        legalMoves: [
+          { from: 10, to: 8, dieUsed: 2, hit: true },
+          { from: 10, to: 6, dieUsed: 4, hit: false },
+          { from: 6, to: 2, dieUsed: 4, hit: false }
+        ],
+        expectedMoveKey: '10->8|2|true'
+      }
+    ];
+
+    for (const fixture of fixtures) {
+      const selected = chooseComputerMove(fixture.state, fixture.legalMoves);
+      expect(moveKey(selected)).toBe(fixture.expectedMoveKey);
+    }
+  });
+
+  it('supports selecting the aggressive profile explicitly', () => {
+    expect(AI_STRATEGY_PROFILES.aggressive).toBeDefined();
+  });
+});

--- a/src/game/ai.js
+++ b/src/game/ai.js
@@ -8,6 +8,45 @@ import {
   opponent
 } from './engine.js';
 
+export const DEFAULT_AI_WEIGHTS = {
+  hitBonus: 35,
+  bearOffBonus: 60,
+  madePointBonus: 16,
+  breakMadePointPenalty: 14,
+  vulnerableBlotPenalty: 10,
+  dieUsedBonus: 1,
+  futureMoveMultiplier: 2
+};
+
+export const AI_STRATEGY_PROFILES = {
+  balanced: DEFAULT_AI_WEIGHTS,
+  aggressive: {
+    ...DEFAULT_AI_WEIGHTS,
+    hitBonus: 45,
+    vulnerableBlotPenalty: 8
+  }
+};
+
+function resolveAiWeights(strategyConfig = null) {
+  if (typeof strategyConfig === 'string') {
+    return AI_STRATEGY_PROFILES[strategyConfig] ?? DEFAULT_AI_WEIGHTS;
+  }
+
+  if (strategyConfig?.profile && AI_STRATEGY_PROFILES[strategyConfig.profile]) {
+    return AI_STRATEGY_PROFILES[strategyConfig.profile];
+  }
+
+  if (strategyConfig?.weights) {
+    return { ...DEFAULT_AI_WEIGHTS, ...strategyConfig.weights };
+  }
+
+  if (strategyConfig) {
+    return { ...DEFAULT_AI_WEIGHTS, ...strategyConfig };
+  }
+
+  return AI_STRATEGY_PROFILES.balanced;
+}
+
 export function chooseMoveForDestination(state, candidateMoves) {
   if (candidateMoves.length <= 1) {
     return candidateMoves[0] ?? null;
@@ -59,49 +98,51 @@ export function destinationIsVulnerableAfterMove(state, move, player) {
   return false;
 }
 
-export function scoreMove(state, move) {
+export function scoreMove(state, move, weights = DEFAULT_AI_WEIGHTS) {
   const player = state.currentPlayer;
   let score = 0;
 
   if (move.hit) {
-    score += 35;
+    score += weights.hitBonus;
   }
   if (move.to === 'off') {
-    score += 60;
+    score += weights.bearOffBonus;
   }
 
   const beforeToCount = move.to === 'off' ? 0 : countAt(state.points, move.to, player);
   const beforeFromCount = move.from === 'bar' ? 0 : countAt(state.points, move.from, player);
 
   if (move.to !== 'off' && beforeToCount >= 1) {
-    score += 16;
+    score += weights.madePointBonus;
   }
   if (move.from !== 'bar' && beforeFromCount === 2) {
-    score -= 14;
+    score -= weights.breakMadePointPenalty;
   }
   if (destinationIsVulnerableAfterMove(state, move, player)) {
-    score -= 10;
+    score -= weights.vulnerableBlotPenalty;
   }
 
-  score += move.dieUsed;
+  score += move.dieUsed * weights.dieUsedBonus;
   return score;
 }
 
-export function chooseComputerMove(state, legalMoves = null) {
+export function chooseComputerMove(state, legalMoves = null, strategyConfig = null) {
   const moves = legalMoves ?? computeLegalMoves(state);
   if (!moves.length) {
     return null;
   }
+
+  const weights = resolveAiWeights(strategyConfig);
 
   let best = moves[0];
   let bestScore = Number.NEGATIVE_INFINITY;
   let bestFuture = -1;
 
   for (const move of moves) {
-    const localScore = scoreMove(state, move);
+    const localScore = scoreMove(state, move, weights);
     const nextState = applyMoveInternal(state, move);
     const future = maxPlayableMoves(nextState);
-    const total = localScore + future * 2;
+    const total = localScore + future * weights.futureMoveMultiplier;
 
     if (total > bestScore) {
       best = move;


### PR DESCRIPTION
### Motivation
- Centralize the numeric scoring constants used by the AI so different play styles can be expressed and tuned in one place.
- Make `scoreMove` and `chooseComputerMove` configurable so the app can support strategy profiles without changing core logic.
- Preserve existing behavior by wiring the app to a `balanced` profile that reproduces pre-refactor decisions.

### Description
- Added `DEFAULT_AI_WEIGHTS` containing the numeric constants previously hard-coded in `scoreMove` and introduced `AI_STRATEGY_PROFILES` with a `balanced` default and an `aggressive` profile. (`src/game/ai.js`)
- Refactored `scoreMove` to accept an optional `weights` parameter (`scoreMove(state, move, weights = DEFAULT_AI_WEIGHTS)`) and replaced hardcoded constants with weight fields. (`src/game/ai.js`)
- Refactored `chooseComputerMove` to accept an optional `strategyConfig` parameter (`chooseComputerMove(state, legalMoves = null, strategyConfig = null)`) and added `resolveAiWeights` to map profile/config to weights; the `balanced` profile is used when none is provided. (`src/game/ai.js`)
- Added unit tests that assert the default behavior equals the `balanced` profile and that pre-refactor fixture move choices remain the same, and added a test that ensures an `aggressive` profile exists (`src/game/__tests__/ai.test.js`).

### Testing
- Added `src/game/__tests__/ai.test.js` which contains tests asserting the default selection matches the `balanced` profile and that three pre-refactor fixtures produce the same chosen moves; these tests were authored to run under the repo's test runner (`vitest`).
- Attempted to run `npx vitest run src/game/__tests__/ai.test.js` but it failed in this environment due to an external npm registry `403 Forbidden` error when fetching `vitest`.
- Performed a manual verification by running a small Node script with `node --input-type=module` that calls `chooseComputerMove` for a representative fixture and confirms the default and explicit `balanced` selections are identical, and that check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7616845c8832e8385feda1aa4d2f5)