### PR TITLE
Remove /play entrypoint and redundant game status/actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import * as defaultMedia from './platform/media.js';
 import * as defaultRandom from './platform/random.js';
 import * as defaultStorage from './platform/storage.js';
 
-export default function App({ showSeo = true, seoPath = '/play', seoTitle = 'Play Backgammon Online Locally', seoDescription = 'Play Backgammon Local against the computer with automatic local save and beginner-friendly controls.', showHeader = true, className = '', adapters = {} }) {
+export default function App({ showSeo = true, seoPath = '/', seoTitle = 'Play Backgammon Online Locally', seoDescription = 'Play Backgammon Local against the computer with automatic local save and beginner-friendly controls.', showHeader = true, className = '', adapters = {} }) {
   const {
     clock = defaultClock,
     media = defaultMedia,
@@ -30,7 +30,7 @@ export default function App({ showSeo = true, seoPath = '/play', seoTitle = 'Pla
       <BoardSurface {...controller} />
 
       {controller.toastMessage && <section className="roll-toast" aria-live="polite">{controller.toastMessage}</section>}
-      {controller.gamePhase !== 'OPENING_ROLL' && <section className="roll-toast" aria-live="polite">{controller.game.statusText}</section>}
+      <section className="roll-toast" aria-live="polite">{controller.gamePhase === 'OPENING_ROLL' ? controller.openingMessage : controller.game.statusText}</section>
 
       <ControlsPanel
         isAnimatingMove={controller.isAnimatingMove}
@@ -38,8 +38,6 @@ export default function App({ showSeo = true, seoPath = '/play', seoTitle = 'Pla
         undoCount={controller.game.undoStack.length}
         onNewGame={controller.handleNewGame}
         onUndo={controller.handleUndo}
-        onResetPosition={controller.handleResetPosition}
-        onClearSavedGame={controller.clearSavedGame}
       />
 
       <DebugPanel

--- a/src/__tests__/App.turn-flow.characterization.test.jsx
+++ b/src/__tests__/App.turn-flow.characterization.test.jsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/vitest';
 import App from '../App.jsx';
-import { STORAGE_KEY } from '../game.js';
 
 function setMatchMedia(prefersReducedMotion) {
   Object.defineProperty(window, 'matchMedia', {
@@ -27,15 +26,6 @@ describe('App turn-flow characterization', () => {
     setMatchMedia(true);
   });
 
-  it('clear saved game removes STORAGE_KEY from localStorage', async () => {
-    window.localStorage.setItem(STORAGE_KEY, '{"seeded":true}');
-    const user = userEvent.setup();
-    render(<App showSeo={false} showHeader={false} />);
-
-    await user.click(screen.getByRole('button', { name: 'Clear Saved Game' }));
-
-    expect(window.localStorage.getItem(STORAGE_KEY)).not.toEqual('{"seeded":true}');
-  });
 
   it('set dice + roll follows forced dice values in status text', async () => {
     const user = userEvent.setup();

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -9,7 +9,6 @@ export default function Layout({ children }) {
           <Link to="/" className="site-title">Backgammon Local</Link>
           <nav aria-label="Primary navigation" className="site-nav">
             <NavLink to="/" className={({ isActive }) => `site-nav-link ${isActive ? 'active' : ''}`}>Home</NavLink>
-            <NavLink to="/play" className={({ isActive }) => `site-nav-link ${isActive ? 'active' : ''}`}>Play</NavLink>
             <NavLink to="/rules" className={({ isActive }) => `site-nav-link ${isActive ? 'active' : ''}`}>Rules</NavLink>
             <NavLink to="/strategy" className={({ isActive }) => `site-nav-link ${isActive ? 'active' : ''}`}>Strategy</NavLink>
             <NavLink to="/faq" className={({ isActive }) => `site-nav-link ${isActive ? 'active' : ''}`}>FAQ</NavLink>

--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -147,7 +147,6 @@ export default function BoardSurface(props) {
       if (event.target.closest('.point.legal, .bearoff-tray.legal')) return;
       cancelPendingPathChoice();
     }}>
-      {gamePhase === 'OPENING_ROLL' && <section className="opening-roll-panel" aria-live="polite"><p className="opening-roll-message">{openingMessage}</p></section>}
       {pendingPathChoices && (
         <section
           className="path-choice-prompt"

--- a/src/components/board/ControlsPanel.jsx
+++ b/src/components/board/ControlsPanel.jsx
@@ -1,10 +1,8 @@
-export default function ControlsPanel({ isAnimatingMove, isAnyRollAnimationRunning, undoCount, onNewGame, onUndo, onResetPosition, onClearSavedGame }) {
+export default function ControlsPanel({ isAnimatingMove, isAnyRollAnimationRunning, undoCount, onNewGame, onUndo }) {
   return (
     <section className="controls" aria-label="Game controls">
       <button type="button" onClick={onNewGame} aria-label="New Game" disabled={isAnimatingMove || isAnyRollAnimationRunning}>New Game</button>
       <button type="button" onClick={onUndo} aria-label="Undo" disabled={isAnimatingMove || isAnyRollAnimationRunning || undoCount === 0}>Undo</button>
-      <button type="button" onClick={onResetPosition} aria-label="Reset to Starting Position" disabled={isAnimatingMove || isAnyRollAnimationRunning}>Reset to Starting Position</button>
-      <button type="button" onClick={onClearSavedGame} aria-label="Clear Saved Game" disabled={isAnimatingMove || isAnyRollAnimationRunning}>Clear Saved Game</button>
     </section>
   );
 }

--- a/src/pages/FaqPage.jsx
+++ b/src/pages/FaqPage.jsx
@@ -40,7 +40,7 @@ const faqItems = [
   },
   {
     q: 'Can I clear saved data?',
-    a: 'Yes. You can use the in-game Clear Saved Game control if available, or remove site data directly in browser settings. Clearing site data removes locally saved game progress for this browser.'
+    a: 'Yes. You can remove site data directly in browser settings. Clearing site data removes locally saved game progress for this browser.'
   },
   {
     q: 'Can I play on mobile?',

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -50,7 +50,6 @@ export default function HomePage() {
       <section className="home-game-hero" aria-labelledby="home-play-heading">
         <div className="home-hero-topline">
           <h1 id="home-play-heading">Play Backgammon Online</h1>
-          <Link className="cta-button cta-secondary" to="/play">Open full screen /play</Link>
         </div>
         <GameExperience showSeo={false} showHeader={false} className="home-embedded-game" />
       </section>

--- a/src/pages/PrivacyPage.jsx
+++ b/src/pages/PrivacyPage.jsx
@@ -12,7 +12,7 @@ export default function PrivacyPage() {
       <p>Backgammon Local runs entirely in your browser and does not require an account.</p>
       <p>Game progress is stored in localStorage so your current match can persist between visits on the same device.</p>
       <p>No server-side game profile is needed for normal use, and no personal information is required to play.</p>
-      <p>To remove saved game data, use the in-game Clear Saved Game action or clear this site&apos;s storage in your browser settings.</p>
+      <p>To remove saved game data, clear this site&apos;s storage in your browser settings.</p>
     </article>
   );
 }

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -1,6 +1,5 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Layout from '../components/Layout.jsx';
-import PlayPage from '../App.jsx';
 import AboutPage from '../pages/AboutPage.jsx';
 import ChangelogPage from '../pages/ChangelogPage.jsx';
 import FaqPage from '../pages/FaqPage.jsx';
@@ -18,7 +17,6 @@ export default function AppRouter() {
       <Layout>
         <Routes>
           <Route path="/" element={<HomePage />} />
-          <Route path="/play" element={<PlayPage />} />
           <Route path="/rules" element={<RulesPage />} />
           <Route path="/strategy" element={<StrategyPage />} />
           <Route path="/faq" element={<FaqPage />} />


### PR DESCRIPTION
### Motivation
- Simplify the UX by keeping gameplay embedded on the home page and removing duplicate controls and a separate /play entrypoint.
- Consolidate opening-roll messaging into the existing centered status bar under the board so the top status banner is no longer necessary.
- Remove controls that exposed extra state management (reset position and clear saved game) from the main controls panel.

### Description
- Stop exposing a separate `/play` route and remove the Play nav item so the game is only reachable as the embedded experience on the home page (`src/router/AppRouter.jsx`, `src/components/Layout.jsx`).
- Remove the home CTA that linked to `/play` and keep the embedded game on the homepage (`src/pages/HomePage.jsx`).
- Render opening-roll copy in the existing centered status bar below the board by replacing the separate `opening-roll` panel, and always render either `controller.openingMessage` or `controller.game.statusText` in the `.roll-toast` region (`src/App.jsx`, `src/components/board/BoardSurface.jsx`).
- Remove `Reset to Starting Position` and `Clear Saved Game` buttons from the controls panel and stop passing those handlers (`src/components/board/ControlsPanel.jsx`, `src/App.jsx`).
- Update help/copy and tests that referenced the removed Clear Saved Game control to reflect removing the in-game control and instruct users to clear site storage instead (`src/pages/FaqPage.jsx`, `src/pages/PrivacyPage.jsx`, `src/__tests__/App.turn-flow.characterization.test.jsx`).

### Testing
- Searched the codebase for removed strings to validate edits with `rg` (pattern checks for removed UI strings), which confirmed the items were removed.
- Attempted a production build via `npm run build`, which failed in this environment because Vite could not resolve local/bundled dependencies (`react-helmet-async` and `react-router-dom`), so a full build verification could not be completed.
- Started the dev server with `npm run dev`, which launched but reported the same unresolved dependency warnings, so live UI validation beyond static checks was limited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb8280878832e876fdae872a043a7)