### PR TITLE
Adjust used-dice dimming order for doubles

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -28,14 +28,19 @@ function getRolledDiceWithUsage(game, { expandDoubles = true } = {}) {
       ? [game.dice.values[0], game.dice.values[0], game.dice.values[0], game.dice.values[0]]
       : game.dice.values;
 
-  return displayDiceValues.map((die) => {
+  const diceWithUsage = Array.from({ length: displayDiceValues.length });
+  for (let i = displayDiceValues.length - 1; i >= 0; i -= 1) {
+    const die = displayDiceValues[i];
     const available = remainingCounts[die] ?? 0;
     if (available > 0) {
       remainingCounts[die] = available - 1;
-      return { value: die, used: false };
+      diceWithUsage[i] = { value: die, used: false };
+      continue;
     }
-    return { value: die, used: true };
-  });
+    diceWithUsage[i] = { value: die, used: true };
+  }
+
+  return diceWithUsage;
 }
 
 function DieFace({ value, className = '', ariaHidden = false, used = false }) {


### PR DESCRIPTION
### Motivation
- Make the visible consumption of dice progress left-to-right (instead of right-to-left) when using doubles so the UI matches expected player preference and the screenshot example.

### Description
- Changed `getRolledDiceWithUsage` in `src/components/board/BoardSurface.jsx` to assign `used` flags by iterating the rendered dice list from the end toward the start so consumed dice are marked right-to-left in data assignment, producing left-to-right greying in the UI.

### Testing
- Built the app with `npm run build`, started the dev server with `npm run dev`, and captured a Playwright screenshot of the updated UI, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e99f8e18832ea09623028182da16)