### PR TITLE
Pause showing no-moves notice before passing turn to computer and add test

### DIFF
--- a/src/__tests__/App.turn-flow.characterization.test.jsx
+++ b/src/__tests__/App.turn-flow.characterization.test.jsx
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/vitest';
 import App from '../App.jsx';
+import { PLAYER_A, SCHEMA_VERSION, STORAGE_KEY } from '../game.js';
 
 function setMatchMedia(prefersReducedMotion) {
   Object.defineProperty(window, 'matchMedia', {
@@ -26,6 +27,32 @@ describe('App turn-flow characterization', () => {
     setMatchMedia(true);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function seedNoMovesOnRollScenario() {
+    const points = Array(24).fill(0);
+    points[18] = -2;
+    points[19] = -2;
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      version: SCHEMA_VERSION,
+      points,
+      bar: { A: 1, B: 0 },
+      bearOff: { A: 0, B: 0 },
+      currentPlayer: PLAYER_A,
+      phase: 'playing',
+      dice: { values: [], remaining: [] },
+      winner: null,
+      openingRollPending: false,
+      openingRoll: { player: 6, computer: 1, status: 'done' },
+      undoStack: [],
+      statusText: 'Player to move. Roll dice.',
+      dev: { debugOpen: false, dieA: 6, dieB: 5 }
+    }));
+  }
+
 
   it('set dice + roll follows forced dice values in status text', async () => {
     const user = userEvent.setup();
@@ -45,5 +72,32 @@ describe('App turn-flow characterization', () => {
     await waitFor(() => {
       expect(screen.getAllByText(/rolled 6 and 5/i).length).toBeGreaterThan(0);
     });
+  });
+
+  it('shows a no-moves notice pause before passing turn to the computer', async () => {
+    vi.useFakeTimers();
+    seedNoMovesOnRollScenario();
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<App showSeo={false} showHeader={false} />);
+
+    await user.click(screen.getByRole('button', { name: 'Toggle debug panel' }));
+    await user.click(screen.getByRole('button', { name: 'Set Dice + Roll' }));
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(screen.getAllByText(/You rolled 6 and 5\. No legal moves\. Turn passes to computer\./i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Roll Dice' })).toBeDisabled();
+    expect(screen.queryByText(/Computer rolled/i)).not.toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(2400);
+    expect(screen.getAllByText(/No legal moves\./i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Computer rolled/i)).not.toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(screen.getAllByText(/No legal moves\./i).length).toBeGreaterThan(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(screen.getByText(/Turn passed to computer\./i)).toBeInTheDocument();
   });
 });

--- a/src/hooks/useGameController.js
+++ b/src/hooks/useGameController.js
@@ -31,6 +31,7 @@ const OPENING_ROLL_DIE_HOLD_MS = 220;
 const OPENING_ROLL_RESULT_MS = 800;
 const OPENING_ROLL_COMPUTER_START_BEAT_MS = 420;
 const COMPUTER_TURN_DELAY_MS = 1000;
+const PLAYER_NO_MOVES_NOTICE_MS = 3500;
 const DICE_USED_STYLE_DELAY_MS = 250;
 
 const destinationKey = (to) => (to === 'off' ? 'off' : String(to));
@@ -198,17 +199,27 @@ export default function useGameController({ clock = defaultClock, media = defaul
     if (isAnimatingRoll) return setPlayerTurnPhase('ROLLING');
     if (game.dice.values.length === 0) return setPlayerTurnPhase('NEED_ROLL');
     if (game.dice.remaining.length > 0 && computeLegalMoves(game).length > 0) return setPlayerTurnPhase('MOVE');
-    if (game.dice.values.length === 2 && game.dice.remaining.length === 0 && computeLegalMoves(game).length === 0) setPlayerTurnPhase('NO_MOVES');
+    if (game.dice.values.length === 2 && game.dice.remaining.length === 0 && computeLegalMoves(game).length === 0) setPlayerTurnPhase('NO_MOVES_NOTICE');
   }, [game, gamePhase, isAnimatingRoll]);
 
   useEffect(() => {
-    if (gamePhase === 'OPENING_ROLL' || game.winner || game.currentPlayer !== PLAYER_A || playerTurnPhase !== 'NO_MOVES') return;
-    setToastMessage('No legal moves — passing turn.');
+    if (gamePhase === 'OPENING_ROLL' || game.winner || game.currentPlayer !== PLAYER_A || playerTurnPhase !== 'NO_MOVES_NOTICE') return;
+    const noMovesMessage = `You rolled ${game.dice.values[0]} and ${game.dice.values[1]}. No legal moves. Turn passes to computer.`;
+    setGame((prev) => {
+      if (
+        prev.winner
+        || prev.currentPlayer !== PLAYER_A
+        || prev.dice.values.length !== 2
+        || prev.dice.remaining.length !== 0
+        || computeLegalMoves(prev).length !== 0
+      ) return prev;
+      if (prev.statusText === noMovesMessage) return prev;
+      return { ...prev, statusText: noMovesMessage };
+    });
     const timer = clock.setTimeout(() => {
-      setGame((prev) => prev.winner || prev.currentPlayer !== PLAYER_A || prev.dice.values.length !== 2 || prev.dice.remaining.length !== 0 || computeLegalMoves(prev).length !== 0 ? prev : pushUndoState(prev, endTurn(prev, `Player rolled ${prev.dice.values[0]} and ${prev.dice.values[1]} but has no legal moves. Turn passed.`)));
-      setToastMessage(null);
+      setGame((prev) => prev.winner || prev.currentPlayer !== PLAYER_A || prev.dice.values.length !== 2 || prev.dice.remaining.length !== 0 || computeLegalMoves(prev).length !== 0 ? prev : pushUndoState(prev, endTurn(prev, `Player rolled ${prev.dice.values[0]} and ${prev.dice.values[1]}. No legal moves. Turn passed to computer.`)));
       setPlayerTurnPhase('NEED_ROLL');
-    }, 900);
+    }, PLAYER_NO_MOVES_NOTICE_MS);
     return () => clock.clearTimeout(timer);
   }, [game, gamePhase, playerTurnPhase]);
 


### PR DESCRIPTION
### Motivation

- Provide a brief visible notice to the player when a roll yields no legal moves before automatically passing the turn to the computer.
- Ensure the no-moves transition behavior is covered by a deterministic test that simulates the scenario and timer behavior.

### Description

- Introduce a new delay constant `PLAYER_NO_MOVES_NOTICE_MS` and change the player turn-phase from `NO_MOVES` to `NO_MOVES_NOTICE` to represent the notice period.
- Update the no-moves effect in `useGameController` to update the in-game `statusText` with a clear "You rolled X and Y. No legal moves. Turn passes to computer." message and to wait `PLAYER_NO_MOVES_NOTICE_MS` before calling `endTurn` via `pushUndoState`.
- Remove the previous toast usage for no-moves and make the status update idempotent (avoids overwriting the same message repeatedly).
- Add a characterization test `shows a no-moves notice pause before passing turn to the computer` that seeds a board state in `localStorage`, uses fake timers via `vitest` to assert the notice appears, that the roll button is disabled during the pause, and that the turn is passed after the configured delay; also restore real timers in `afterEach` and import `PLAYER_A`, `SCHEMA_VERSION`, and `STORAGE_KEY` for seeding.

### Testing

- Ran the test suite with `vitest`, and the updated tests (including the new no-moves notice test) passed. 
- The new test uses `vi.useFakeTimers()` and `vi.advanceTimersByTimeAsync()` to validate timing-sensitive behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bc2b2920832e9bec9e89fcfcb0e5)