### PR TITLE
Refine pip chip layout for compact mobile and updated pip text

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -151,11 +151,11 @@ export default function BoardSurface(props) {
         <div className="pip-row" aria-label="Pip counts">
           <div className={`pip-box pip-box-computer ${!game.winner && isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
             <span className="pip-box-label">Computer</span>
-            <span className="pip-box-metric"><span className="pip-box-value">{computerPipCount}</span><span className="pip-box-unit">PIP</span></span>
+            <span className="pip-box-metric"><span className="pip-box-unit">PIP:</span><span className="pip-box-value">{computerPipCount}</span></span>
           </div>
           <div className={`pip-box pip-box-player ${!game.winner && !isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
             <span className="pip-box-label">Player</span>
-            <span className="pip-box-metric"><span className="pip-box-value">{playerPipCount}</span><span className="pip-box-unit">PIP</span></span>
+            <span className="pip-box-metric"><span className="pip-box-unit">PIP:</span><span className="pip-box-value">{playerPipCount}</span></span>
           </div>
         </div>
         <div className="board-surface">

--- a/src/styles.css
+++ b/src/styles.css
@@ -199,14 +199,14 @@ button:focus-visible {
 
 .board-stage {
   position: relative;
-  margin-top: 0.35rem;
+  margin-top: 0.2rem;
 }
 
 .game-layout {
   display: grid;
   grid-template-columns: 1fr minmax(90px, 110px);
   grid-template-rows: auto 1fr;
-  row-gap: 0.5rem;
+  row-gap: 0.35rem;
   column-gap: clamp(0.38rem, 0.7vw, 0.6rem);
   align-items: start;
   min-width: 0;
@@ -300,7 +300,7 @@ button:focus-visible {
 
 .pip-box {
   width: clamp(150px, 19vw, 190px);
-  min-height: clamp(48px, 6.5vh, 64px);
+  min-height: clamp(44px, 5.4vh, 56px);
   min-width: 0;
   border-radius: 0.72rem;
   border: 2px solid #5b3f2b;
@@ -309,7 +309,7 @@ button:focus-visible {
   box-shadow:
     inset 0 1px 3px rgba(0, 0, 0, 0.14),
     0 2px 6px rgba(31, 18, 8, 0.16);
-  padding: 0.32rem 0.65rem;
+  padding: 0.26rem 0.62rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -343,13 +343,13 @@ button:focus-visible {
 }
 
 .pip-box-value {
-  font-size: clamp(1.4rem, 2.2vw, 1.75rem);
+  font-size: clamp(1.18rem, 1.95vw, 1.5rem);
   font-weight: 800;
   line-height: 0.95;
 }
 
 .pip-box-unit {
-  font-size: 0.63rem;
+  font-size: 0.66rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -979,17 +979,60 @@ button:focus-visible {
 }
 
 @media (max-width: 760px) {
+  .game-layout {
+    row-gap: 0.26rem;
+  }
+
   .pip-row {
     justify-content: space-between;
-    align-items: center;
-    gap: 0.4rem;
+    align-items: stretch;
+    gap: 0.34rem;
+    flex-wrap: wrap;
   }
 
   .pip-box {
-    width: clamp(140px, 44vw, 170px);
+    flex: 1 1 calc(50% - 0.17rem);
+    width: auto;
     min-width: 0;
-    min-height: clamp(44px, 10vw, 56px);
-    padding: 0.3rem 0.55rem;
+    min-height: 42px;
+    padding: 0.2rem 0.45rem;
+    border-radius: 0.56rem;
+    align-items: center;
+    justify-content: center;
+    flex-direction: row;
+    gap: 0.34rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .pip-box-label,
+  .pip-box-metric,
+  .pip-box-unit,
+  .pip-box-value {
+    line-height: 1;
+  }
+
+  .pip-box-label {
+    font-size: 0.58rem;
+  }
+
+  .pip-box-label::after {
+    content: '\00B7';
+    margin-left: 0.24rem;
+    opacity: 0.72;
+  }
+
+  .pip-box-metric {
+    gap: 0.16rem;
+  }
+
+  .pip-box-unit {
+    font-size: 0.58rem;
+  }
+
+  .pip-box-value {
+    font-size: clamp(0.95rem, 3.6vw, 1.1rem);
   }
 
   .app {
@@ -1078,31 +1121,40 @@ button:focus-visible {
 
 }
 
-@media (max-width: 560px) {
+
+@media (max-width: 420px) {
   .pip-row {
     flex-direction: column;
-    align-items: center;
-    gap: 0.45rem;
+    align-items: stretch;
   }
 
   .pip-box {
-    width: min(100%, 170px);
+    flex: 1 1 100%;
+    width: 100%;
+    min-height: 40px;
+  }
+}
+@media (max-width: 560px) {
+  .pip-row {
+    gap: 0.28rem;
+  }
+
+  .pip-box {
     border-width: 1.5px;
-    border-radius: 0.58rem;
-    min-height: clamp(44px, 12vw, 54px);
-    padding: 0.32rem 0.5rem;
+    min-height: 40px;
+    padding: 0.18rem 0.42rem;
   }
 
   .pip-box-label {
-    font-size: 0.62rem;
+    font-size: 0.56rem;
   }
 
   .pip-box-value {
-    font-size: clamp(1.38rem, 6.4vw, 1.6rem);
+    font-size: clamp(0.92rem, 3.8vw, 1.02rem);
   }
 
   .pip-box-unit {
-    font-size: 0.6rem;
+    font-size: 0.55rem;
   }
 
   :root {


### PR DESCRIPTION
### Motivation

- Mobile pip chips were rendering as tall, centered cards that felt detached and consumed too much vertical space; the intent is a compact, board-attached mobile presentation.  
- The pip label format should be clearer and consistent (`PIP: 167` instead of `167 PIP`).  
- Preserve desktop appearance (compact, narrow chips above board corners) while adding a true mobile-specific layout that is short and non-intrusive.

### Description

- Changed the pip metric rendering in `BoardSurface` so the text reads `PIP: <value>` instead of `<value> PIP` by updating the JSX in `src/components/board/BoardSurface.jsx`.  
- Tightened spacing around the board and chip sizes by reducing margins, padding, and chip min-height in `src/styles.css` so desktop chips stay compact and board-adjacent.  
- Implemented mobile-specific styles in `src/styles.css` (media queries at `max-width: 760px`, `560px`, and `420px`) that render pip chips as compact, horizontal status bars side-by-side when space allows, and as short stacked bars on very narrow screens; added overflow-safe sizing and `white-space: nowrap` with ellipsis to prevent horizontal scrolling.  
- Kept the existing active-player highlight (`pip-box-active` blue border/glow) intact so the current-player indicator still applies in the new compact mobile UI.  
- No game logic changed; all edits are presentational only (`src/components/board/BoardSurface.jsx`, `src/styles.css`).

### Testing

- Ran `npm run build` and the production build completed successfully.  
- Launched the dev server with `npm run dev` and verified the UI via automated Playwright captures for mobile and desktop viewports; both screenshots were produced successfully.  
- No automated unit tests were modified or required; changes are styling and UI-only and validated by the successful build and automated visual checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fdaa9cd0832e8ec277a218aefa72)