### PR TITLE
Refine pip chip text alignment and typography

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -151,11 +151,11 @@ export default function BoardSurface(props) {
         <div className="pip-row" aria-label="Pip counts">
           <div className={`pip-box pip-box-computer ${!game.winner && isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
             <span className="pip-box-label">Computer</span>
-            <span className="pip-box-metric"><span className="pip-box-unit">PIP:</span><span className="pip-box-value">{computerPipCount}</span></span>
+            <span className="pip-box-value">{computerPipCount}</span>
           </div>
           <div className={`pip-box pip-box-player ${!game.winner && !isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
             <span className="pip-box-label">Player</span>
-            <span className="pip-box-metric"><span className="pip-box-unit">PIP:</span><span className="pip-box-value">{playerPipCount}</span></span>
+            <span className="pip-box-value">{playerPipCount}</span>
           </div>
         </div>
         <div className="board-surface">

--- a/src/styles.css
+++ b/src/styles.css
@@ -311,11 +311,10 @@ button:focus-visible {
     0 2px 6px rgba(31, 18, 8, 0.16);
   padding: 0.26rem 0.62rem;
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
-  gap: 0.1rem;
-  text-align: center;
+  gap: 0.4rem;
+  text-align: left;
 }
 
 .pip-box-active {
@@ -327,33 +326,21 @@ button:focus-visible {
 }
 
 .pip-box-label {
-  font-size: 0.66rem;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.11em;
   line-height: 1;
   opacity: 0.9;
 }
 
-.pip-box-metric {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.28rem;
-  line-height: 1;
-}
-
 .pip-box-value {
-  font-size: clamp(1.18rem, 1.95vw, 1.5rem);
-  font-weight: 800;
-  line-height: 0.95;
-}
-
-.pip-box-unit {
-  font-size: 0.66rem;
+  font-size: 22px;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  opacity: 0.84;
+  line-height: 1;
+  margin-left: auto;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .board-dice-overlay {
@@ -997,42 +984,21 @@ button:focus-visible {
     min-height: 42px;
     padding: 0.2rem 0.45rem;
     border-radius: 0.56rem;
-    align-items: center;
-    justify-content: center;
-    flex-direction: row;
-    gap: 0.34rem;
+    gap: 0.3rem;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .pip-box-label,
-  .pip-box-metric,
-  .pip-box-unit,
   .pip-box-value {
     line-height: 1;
   }
 
   .pip-box-label {
-    font-size: 0.58rem;
-  }
-
-  .pip-box-label::after {
-    content: '\00B7';
-    margin-left: 0.24rem;
-    opacity: 0.72;
-  }
-
-  .pip-box-metric {
-    gap: 0.16rem;
-  }
-
-  .pip-box-unit {
-    font-size: 0.58rem;
+    font-size: 10px;
   }
 
   .pip-box-value {
-    font-size: clamp(0.95rem, 3.6vw, 1.1rem);
+    font-size: clamp(18px, 4.8vw, 20px);
   }
 
   .app {
@@ -1146,15 +1112,11 @@ button:focus-visible {
   }
 
   .pip-box-label {
-    font-size: 0.56rem;
+    font-size: 9px;
   }
 
   .pip-box-value {
-    font-size: clamp(0.92rem, 3.8vw, 1.02rem);
-  }
-
-  .pip-box-unit {
-    font-size: 0.55rem;
+    font-size: clamp(17px, 4.9vw, 18px);
   }
 
   :root {


### PR DESCRIPTION
### Motivation
- The existing pip chip text (e.g. `COMPUTER · PIP: 158`) looked visually unbalanced and the numeric pip value was not aligned cleanly with the label. 
- The goal is to present a two-part layout with the label left and the pip number right so pip counts read clearly (e.g. `COMPUTER      158` / `PLAYER        167`).
- Changes must preserve the existing chip size, background, borders, active highlight behavior, and game logic.

### Description
- Updated markup in `src/components/board/BoardSurface.jsx` to remove the `PIP:` unit and render only a left `pip-box-label` and a right `pip-box-value` inside each `.pip-box` container. 
- Reworked `.pip-box` internals in `src/styles.css` to use a row flex layout with `justify-content: space-between` and `align-items: center` so label and number are opposite and vertically aligned. 
- Implemented the requested typography hierarchy by setting the label to `font-size: 11px`, `font-weight: 600`, increased letter-spacing, and the number to `font-size: 22px`, `font-weight: 700`, right-aligned with `font-variant-numeric: tabular-nums` for consistent vertical alignment. 
- Adjusted responsive media-query sizes for `.pip-box-label` and `.pip-box-value` to retain good appearance on smaller screens while keeping the chip container visuals and active highlight behavior unchanged. 

### Testing
- Ran `npm run build` which initially failed due to a missing dependency in the environment, then ran `npm install` and re-ran `npm run build` which completed successfully. 
- Launched the dev server and ran an automated Playwright script to capture a full-page screenshot (`artifacts/pip-chip-layout.png`) to visually validate the updated pip-chip layout. 
- No game logic tests were modified and functionality was preserved; the build and the screenshot validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b400ac442c832e8c663225961c410d)