### PR TITLE
Add Terms of Service and Contact pages with routing and footer links

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -24,6 +24,8 @@ export default function Layout({ children }) {
           <NavLink to="/single-player-backgammon">Single Player</NavLink>
           <NavLink to="/free-backgammon-online">Free Backgammon</NavLink>
           <NavLink to="/about">About</NavLink>
+          <NavLink to="/contact">Contact</NavLink>
+          <NavLink to="/terms">Terms of Service</NavLink>
           <NavLink to="/privacy">Privacy</NavLink>
           <NavLink to="/changelog">Changelog</NavLink>
         </nav>

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -1,0 +1,56 @@
+import SEO from '../components/SEO.jsx';
+
+export default function ContactPage() {
+  return (
+    <article className="content-page">
+      <SEO
+        title="Contact | Backgammon Local"
+        description="Contact the site owner with questions, bug reports, or feedback about this browser-based backgammon game."
+        path="/contact"
+      />
+      <h1>Contact</h1>
+      <p>
+        Thanks for playing Backgammon Local. If you have feedback, spot a bug, or want to ask a question about how the game works, we&apos;d
+        love to hear from you. This project is browser-based and built to stay simple, so direct feedback helps improve both gameplay and
+        usability over time.
+      </p>
+      <p>
+        Whether you are a brand-new player using the rules pages or a regular player practicing against the computer, your input is useful.
+        Small reports often uncover issues quickly, and practical suggestions help prioritize quality-of-life improvements.
+      </p>
+      <p>
+        The easiest way to reach out is by email: <a href="mailto:contact@example.com">contact@example.com</a>
+      </p>
+      {/* TODO: Replace placeholder contact@example.com with the production support email before launch. */}
+
+      <h2>Common reasons to contact us</h2>
+      <p>You can contact us for things like:</p>
+      <ul>
+        <li>Bug reports or unexpected game behavior.</li>
+        <li>Gameplay feedback, including difficulty and AI behavior.</li>
+        <li>Questions about rules, legal moves, or page content.</li>
+        <li>Business or partnership inquiries.</li>
+      </ul>
+
+      <h2>How to report a bug effectively</h2>
+      <p>
+        If you&apos;re reporting a bug, adding a little technical detail makes it much easier to diagnose. Please include your device type,
+        operating system, browser name and version, and what you were doing just before the issue happened.
+      </p>
+      <p>
+        It also helps to include the exact dice roll or board situation when possible, plus any error messages you saw. If the issue is
+        visual, a screenshot is useful. If the bug can be reproduced consistently, list clear steps in order so we can verify it quickly.
+      </p>
+
+      <h2>Response expectations</h2>
+      <p>
+        We may not be able to reply immediately to every message, but all feedback is reviewed and used to guide improvements. Clear,
+        respectful reports are appreciated and usually lead to faster fixes.
+      </p>
+      <p>
+        If your message is about a production-critical issue, include that in the subject line and provide as much context as possible in the
+        first email.
+      </p>
+    </article>
+  );
+}

--- a/src/pages/TermsPage.jsx
+++ b/src/pages/TermsPage.jsx
@@ -1,0 +1,147 @@
+import SEO from '../components/SEO.jsx';
+
+export default function TermsPage() {
+  return (
+    <article className="content-page">
+      <SEO
+        title="Terms of Service | Backgammon Local"
+        description="Read the Terms of Service for this browser-based backgammon website, including acceptable use, disclaimers, and limitations of liability."
+        path="/terms"
+      />
+      <h1>Terms of Service</h1>
+      <p>
+        These Terms of Service explain how you may use Backgammon Local, a browser-based backgammon website. We wrote these terms in plain
+        language so they are easy to read and practical to follow. By accessing or using this site, you agree to these terms. If you do not
+        agree, please do not use the site.
+      </p>
+      <p>
+        Backgammon Local is designed as a lightweight game experience that runs in your browser, with supporting pages like rules, strategy,
+        and FAQ content. These terms are intended to set clear expectations about acceptable use, service limitations, and how to contact us
+        when questions come up.
+      </p>
+
+      <h2>Acceptance of terms</h2>
+      <p>
+        By visiting this website, loading the game, or using any of its pages, you confirm that you accept these Terms of Service and our
+        Privacy page. These terms apply to all visitors and users.
+      </p>
+      <p>
+        You are responsible for using the site in compliance with your local laws. If you are using the site on behalf of an organization,
+        you confirm you have authority to accept these terms for that organization.
+      </p>
+      <p>
+        If you disagree with any part of these terms, your remedy is to stop using the website. Continuing to use the site after terms are
+        updated means you accept the revised version.
+      </p>
+
+      <h2>Use of the site</h2>
+      <p>
+        Backgammon Local is provided for normal, personal use as an online game and learning resource. You agree not to misuse the site. For
+        example, you agree not to:
+      </p>
+      <ul>
+        <li>Attempt to interfere with the site&apos;s normal operation or availability.</li>
+        <li>Use automated systems in a way that creates unreasonable load or disrupts other users.</li>
+        <li>Attempt to access non-public parts of the app, infrastructure, or source systems without permission.</li>
+        <li>Use the site for unlawful, abusive, or fraudulent activity.</li>
+      </ul>
+      <p>
+        You also agree not to attempt to reverse engineer or exploit the site in a way that harms reliability, security, or user experience.
+        We may limit, suspend, or block access when needed to protect the service, users, or infrastructure.
+      </p>
+
+      <h2>Browser-based gameplay and local save behavior</h2>
+      <p>
+        Backgammon Local runs in your browser. Gameplay state may be saved locally on your device through browser storage so your current
+        game can persist between visits on the same browser.
+      </p>
+      <p>
+        Because saved data is local to your device, it may be removed if you clear browser storage, use private browsing, reset your browser,
+        install certain extensions, or switch devices/browsers. We cannot guarantee recovery of locally stored game data.
+      </p>
+      <p>
+        We do not promise continuous compatibility with every browser version, plugin, or device configuration. You are responsible for your
+        own device, browser settings, and any local data management choices.
+      </p>
+
+      <h2>No guarantees / no warranties</h2>
+      <p>
+        The site is provided on an &quot;as is&quot; and &quot;as available&quot; basis. We do not promise that the service will always be uninterrupted,
+        error-free, secure, or perfectly accurate in all situations.
+      </p>
+      <p>
+        To the fullest extent allowed by law, we disclaim warranties of any kind, whether express or implied, including implied warranties of
+        merchantability, fitness for a particular purpose, and non-infringement.
+      </p>
+      <p>
+        We do not guarantee that any specific gameplay outcome, strategic guidance, or educational content will meet your expectations.
+        Backgammon involves chance and decision-making; results can vary from game to game.
+      </p>
+
+      <h2>Limitation of liability</h2>
+      <p>
+        To the fullest extent allowed by law, Backgammon Local and its operators are not liable for indirect, incidental, special,
+        consequential, or punitive damages, or for loss of data, loss of use, or loss of goodwill resulting from your use of the site.
+      </p>
+      <p>
+        This includes situations such as interruptions, browser compatibility issues, local storage loss, bugs, temporary downtime, or
+        unexpected behavior in the interface.
+      </p>
+      <p>
+        If liability cannot be excluded under applicable law, liability will be limited to the minimum amount permitted by law. Nothing in
+        these terms excludes rights that cannot be waived under applicable consumer protection laws.
+      </p>
+
+      <h2>Intellectual property</h2>
+      <p>
+        The site&apos;s original content, branding, and presentation, including text, layout, and design elements, are protected by applicable
+        intellectual property laws. You may use the site for personal use, but you may not reproduce, republish, or commercially distribute
+        site content without permission, except where law allows otherwise.
+      </p>
+      <p>
+        You may quote small excerpts for commentary or educational reference where allowed by law, as long as you provide proper attribution
+        and do not imply endorsement.
+      </p>
+      <p>
+        Third-party libraries and tools may be used in the project under their own licenses. Rights to third-party materials remain with
+        their respective owners.
+      </p>
+
+      <h2>Third-party services and hosting</h2>
+      <p>
+        The website may rely on third-party infrastructure or service providers (for example, hosting, content delivery, or analytics tools)
+        to operate. We are not responsible for outages or issues caused by third-party services.
+      </p>
+      <p>
+        If the site includes links to third-party websites, those links are provided for convenience only. We do not control third-party
+        sites and are not responsible for their content, availability, or practices.
+      </p>
+      <p>
+        Your use of third-party tools or links, if present, may also be subject to those third parties&apos; own terms and privacy policies.
+      </p>
+
+      <h2>Changes to the service</h2>
+      <p>
+        We may update, modify, pause, or discontinue parts of the site at any time, including gameplay features, content pages, and technical
+        implementation. We may also update these Terms of Service when needed.
+      </p>
+      <p>
+        We may make these changes for many reasons, including maintenance, quality improvements, bug fixes, legal compliance, or project
+        direction changes. We do not guarantee that every feature will remain available permanently.
+      </p>
+      <p>
+        When terms are updated, the updated version on this page becomes effective when posted. Continuing to use the site after updates
+        means you accept the revised terms.
+      </p>
+
+      <h2>Contact for questions about terms</h2>
+      <p>
+        If you have questions about these terms, please contact us at <a href="mailto:contact@example.com">contact@example.com</a>.
+      </p>
+      <p>
+        <strong>Note:</strong> This address is currently a placeholder and should be replaced with a real support contact before production
+        use.
+      </p>
+    </article>
+  );
+}

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Layout from '../components/Layout.jsx';
 import AboutPage from '../pages/AboutPage.jsx';
 import ChangelogPage from '../pages/ChangelogPage.jsx';
+import ContactPage from '../pages/ContactPage.jsx';
 import FaqPage from '../pages/FaqPage.jsx';
 import FreeBackgammonPage from '../pages/FreeBackgammonPage.jsx';
 import GlossaryPage from '../pages/GlossaryPage.jsx';
@@ -10,6 +11,7 @@ import PrivacyPage from '../pages/PrivacyPage.jsx';
 import RulesPage from '../pages/RulesPage.jsx';
 import SinglePlayerPage from '../pages/SinglePlayerPage.jsx';
 import StrategyPage from '../pages/StrategyPage.jsx';
+import TermsPage from '../pages/TermsPage.jsx';
 
 export default function AppRouter() {
   return (
@@ -24,7 +26,9 @@ export default function AppRouter() {
           <Route path="/single-player-backgammon" element={<SinglePlayerPage />} />
           <Route path="/free-backgammon-online" element={<FreeBackgammonPage />} />
           <Route path="/about" element={<AboutPage />} />
+          <Route path="/contact" element={<ContactPage />} />
           <Route path="/privacy" element={<PrivacyPage />} />
+          <Route path="/terms" element={<TermsPage />} />
           <Route path="/changelog" element={<ChangelogPage />} />
           <Route path="*" element={<HomePage />} />
         </Routes>


### PR DESCRIPTION
### Motivation
- Provide the remaining high-value trust/legal pages (Terms of Service and Contact) so visitors can find legal terms and a clear support contact for a browser-based app.
- Make the pages clear, readable, and consistent with existing content pages while accurately reflecting browser-only behavior and local storage for saved games.

### Description
- Added `src/pages/TermsPage.jsx` implementing the `/terms` route with a single `h1`, plain-English sections (acceptance, use, local save behavior, warranties, liability, IP, third-party services, changes), and SEO metadata via the existing `SEO` component.
- Added `src/pages/ContactPage.jsx` implementing the `/contact` route with guidance for feedback and bug reports, an email link, and a TODO placeholder `contact@example.com` to be replaced before production.
- Registered the new routes in `src/router/AppRouter.jsx` and added `Contact` and `Terms of Service` links to the footer in `src/components/Layout.jsx` without changing game logic or top navigation.
- Kept styling and structure consistent by reusing the `content-page` class and the existing `SEO` pattern for canonical URL, title, and description.

### Testing
- Ran `npm install` to resolve dependencies and then `npm run build`, which completed successfully and produced a production build.
- Started the dev server with `npm run dev` and performed automated page checks by capturing screenshots of `/terms` and `/contact` via a Playwright script to verify pages render.  
- No unit tests were changed or required for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b448e934d0832e8c286489612f18b4)