### PR TITLE
Add end-of-game winner overlay with Play Again / Review Board actions

### DIFF
--- a/src/__tests__/App.endgame-overlay.test.jsx
+++ b/src/__tests__/App.endgame-overlay.test.jsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import App from '../App.jsx';
+import { PLAYER_A, PLAYER_B, SCHEMA_VERSION, STORAGE_KEY } from '../game.js';
+
+function seedFinishedGame(winner) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify({
+    version: SCHEMA_VERSION,
+    points: Array(24).fill(0),
+    bar: { A: 0, B: 0 },
+    bearOff: winner === PLAYER_A ? { A: 15, B: 8 } : { A: 9, B: 15 },
+    currentPlayer: PLAYER_A,
+    phase: 'playing',
+    dice: { values: [3, 2], remaining: [] },
+    winner,
+    openingRollPending: false,
+    openingRoll: { player: 6, computer: 1, status: 'done' },
+    undoStack: [],
+    statusText: winner === PLAYER_A ? 'Player wins.' : 'Computer wins.',
+    dev: { debugOpen: false, dieA: 6, dieB: 5 }
+  }));
+}
+
+describe('App end-of-game overlay', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('shows winner overlay and lets players review the final board', async () => {
+    seedFinishedGame(PLAYER_A);
+    const user = userEvent.setup();
+
+    render(<App showSeo={false} showHeader={false} />);
+
+    expect(screen.getByRole('heading', { name: 'You win!' })).toBeInTheDocument();
+    expect(screen.getByText('You bore off all 15 checkers first.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Review Board' }));
+
+    expect(screen.queryByRole('heading', { name: 'You win!' })).not.toBeInTheDocument();
+    expect(screen.getByText('Player wins.')).toBeInTheDocument();
+  });
+
+  it('starts a fresh game from the overlay primary action', async () => {
+    seedFinishedGame(PLAYER_B);
+    const user = userEvent.setup();
+
+    render(<App showSeo={false} showHeader={false} />);
+
+    expect(screen.getByRole('heading', { name: 'Computer wins' })).toBeInTheDocument();
+    expect(screen.getByText('The computer bore off all 15 checkers first.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Play Again' }));
+
+    expect(screen.queryByRole('heading', { name: 'Computer wins' })).not.toBeInTheDocument();
+    expect(screen.getByText('Opening roll — highest die goes first.')).toBeInTheDocument();
+  });
+});

--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -124,14 +124,24 @@ export default function BoardSurface(props) {
     moveToDestination, handleSelectSource, isAnimatingMove, diceAnimKey, isAnyRollAnimationRunning,
     pendingRoll, disableUsedDiceStyling, movingChecker, moveStepMs,
     pendingPathChoices, chooseIntermediatePath, cancelPendingPathChoice,
-    canPlayerRoll, handleRoll
+    canPlayerRoll, handleRoll, handleNewGame, isEndGameOverlayOpen, closeEndGameOverlay
   } = props;
+
+  const winnerCopy = game.winner === PLAYER_A
+    ? {
+      title: 'You win!',
+      subtitle: 'You bore off all 15 checkers first.'
+    }
+    : {
+      title: 'Computer wins',
+      subtitle: 'The computer bore off all 15 checkers first.'
+    };
 
   const renderPoint = (point, isTop) => <Point key={point} index={point} value={game.points[point]} isTop={isTop} pointRef={(node) => {
     if (node) pointRefs.current.set(point, node);
     else pointRefs.current.delete(point);
   }} selected={activeSelectedSource === point} highlighted={destinationSet.has(String(point))} pathChoiceIntermediate={pendingIntermediateSet.has(String(point))} movable={showMovableSources && movableSourceSet.has(String(point))} onClick={() => {
-    if (isAnimatingMove || isComputerTurn) return;
+    if (isEndGameOverlayOpen || isAnimatingMove || isComputerTurn) return;
     if (pendingPathChoices) {
       if (destinationSet.has(String(point))) chooseIntermediatePath(point);
       else cancelPendingPathChoice();
@@ -143,11 +153,11 @@ export default function BoardSurface(props) {
 
   return (
     <section ref={boardStageRef} className={`board-stage ${pendingPathChoices ? 'pending-path-choice' : ''}`.trim()} aria-label="Backgammon board" onClick={(event) => {
-      if (!pendingPathChoices) return;
+      if (isEndGameOverlayOpen || !pendingPathChoices) return;
       if (event.target.closest('.point.legal, .bearoff-tray.legal')) return;
       cancelPendingPathChoice();
     }}>
-      <div className="game-layout">
+      <div className={`game-layout ${isEndGameOverlayOpen ? 'game-layout-overlay-open' : ''}`.trim()}>
         <div className="pip-row" aria-label="Pip counts">
           <div className={`pip-box pip-box-computer ${!game.winner && isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
             <span className="pip-box-label">Computer</span>
@@ -163,7 +173,7 @@ export default function BoardSurface(props) {
           <div className="point-band top-band top-right-band">{TOP_RIGHT.map((point) => renderPoint(point, true))}</div>
           <Bar game={game} activeSelectedSource={activeSelectedSource} showMovableSources={showMovableSources} movableSourceSet={movableSourceSet} destinationSet={destinationSet} onSelectBar={() => {
             if (pendingPathChoices) return cancelPendingPathChoice();
-            if (!isAnimatingMove && !isComputerTurn) handleSelectSource('bar');
+            if (!isEndGameOverlayOpen && !isAnimatingMove && !isComputerTurn) handleSelectSource('bar');
           }} barRef={barRef} />
           <div className="point-band bottom-band bottom-left-band">{BOTTOM_LEFT.map((point) => renderPoint(point, false))}</div>
           <div className="point-band bottom-band bottom-right-band">{BOTTOM_RIGHT.map((point) => renderPoint(point, false))}</div>
@@ -173,14 +183,26 @@ export default function BoardSurface(props) {
         <aside className="home-rail" aria-label="Bear off area">
           <BearOffTray label="Computer" title="COMPUTER OFF" checkerIcon="⚫" className="home-top" trayRef={(node) => { bearOffRefs.current.B = node; }} count={game.bearOff.B} highlighted={destinationSet.has('off') && game.currentPlayer === PLAYER_B} pathChoiceIntermediate={pendingIntermediateSet.has('off')} onClick={() => {
             if (pendingPathChoices) return cancelPendingPathChoice();
-            if (!isAnimatingMove && !isComputerTurn) moveToDestination('off');
+            if (!isEndGameOverlayOpen && !isAnimatingMove && !isComputerTurn) moveToDestination('off');
           }} />
           <BearOffTray label="Player" title="PLAYER OFF" checkerIcon="⚪" className="home-bottom" trayRef={(node) => { bearOffRefs.current.A = node; }} count={game.bearOff.A} highlighted={destinationSet.has('off') && game.currentPlayer === PLAYER_A} pathChoiceIntermediate={pendingIntermediateSet.has('off')} onClick={() => {
             if (pendingPathChoices) return cancelPendingPathChoice();
-            if (!isAnimatingMove && !isComputerTurn) moveToDestination('off');
+            if (!isEndGameOverlayOpen && !isAnimatingMove && !isComputerTurn) moveToDestination('off');
           }} />
         </aside>
       </div>
+      {isEndGameOverlayOpen && game.winner && (
+        <div className="endgame-overlay" role="dialog" aria-modal="true" aria-label="Game over">
+          <div className="endgame-overlay-card">
+            <h2>{winnerCopy.title}</h2>
+            <p>{winnerCopy.subtitle}</p>
+            <div className="endgame-overlay-actions">
+              <button type="button" className="button-primary" onClick={handleNewGame}>Play Again</button>
+              <button type="button" className="button-secondary" onClick={closeEndGameOverlay}>Review Board</button>
+            </div>
+          </div>
+        </div>
+      )}
       {movingChecker && <span aria-hidden="true" className={`checker moving-checker checker-${movingChecker.player === 'B' ? 'b' : 'a'}`} style={{ left: `${movingChecker.x}px`, top: `${movingChecker.y}px`, '--move-step-ms': `${moveStepMs}ms` }} />}
     </section>
   );

--- a/src/hooks/useGameController.js
+++ b/src/hooks/useGameController.js
@@ -51,6 +51,7 @@ export default function useGameController({ clock = defaultClock, media = defaul
   const [toastMessage, setToastMessage] = useState(null);
   const [playerTurnPhase, setPlayerTurnPhase] = useState('NEED_ROLL');
   const [pendingPathChoices, setPendingPathChoices] = useState(null);
+  const [isEndGameOverlayOpen, setIsEndGameOverlayOpen] = useState(false);
 
   const boardStageRef = useRef(null);
   const pointRefs = useRef(new Map());
@@ -164,6 +165,9 @@ export default function useGameController({ clock = defaultClock, media = defaul
   useEffect(() => { saveGameState(game, storage); }, [game, storage]);
   useEffect(() => { if (selectedSource != null && !movesBySource.has(sourceKey(selectedSource))) setSelectedSource(null); }, [movesBySource, selectedSource]);
   useEffect(() => { setPendingPathChoices(null); }, [selectedSource, game]);
+  useEffect(() => {
+    setIsEndGameOverlayOpen(Boolean(game.winner));
+  }, [game.winner]);
   useEffect(() => {
     if (!pendingPathChoices) return undefined;
     const onEscape = (event) => {
@@ -477,23 +481,30 @@ export default function useGameController({ clock = defaultClock, media = defaul
   function handleNewGame() {
     if (isAnimatingMove) return;
     resetFlowState();
+    setIsEndGameOverlayOpen(false);
     setGame((prev) => pushUndoState(prev, createInitialState()));
   }
   function handleResetPosition() {
     if (isAnimatingMove) return;
     resetFlowState();
+    setIsEndGameOverlayOpen(false);
     setGame((prev) => pushUndoState(prev, { ...createInitialState(), undoStack: prev.undoStack, dev: prev.dev }));
   }
   function handleUndo() {
     if (isAnimatingMove) return;
     resetFlowState();
+    setIsEndGameOverlayOpen(false);
     setGame((prev) => undo(prev));
   }
   function clearSavedGame() {
     if (isAnimatingMove) return;
     resetFlowState();
+    setIsEndGameOverlayOpen(false);
     clearSavedGameState(storage);
     setGame(createInitialState());
+  }
+  function closeEndGameOverlay() {
+    setIsEndGameOverlayOpen(false);
   }
   function updateDebugDie(key, value) {
     const n = Math.max(1, Math.min(6, Number(value) || 1));
@@ -612,9 +623,9 @@ export default function useGameController({ clock = defaultClock, media = defaul
     game, gamePhase, openingMessage, statusMessage, playerPipCount, computerPipCount, canPlayerRoll, isComputerTurn, isAnimatingMove,
     isAnyRollAnimationRunning, diceAnimKey, pendingRoll, disableUsedDiceStyling, toastMessage, movingChecker,
     activeSelectedSource, destinationSet, movableSourceSet, showMovableSources, moveStepMs: MOVE_STEP_MS,
-    pendingPathChoices, pendingIntermediateSet,
+    pendingPathChoices, pendingIntermediateSet, isEndGameOverlayOpen,
     boardStageRef, pointRefs, barRef, bearOffRefs,
-    handleRoll, handleSelectSource, moveToDestination, chooseIntermediatePath, cancelPendingPathChoice, handleUndo, handleNewGame, handleResetPosition, clearSavedGame,
+    handleRoll, handleSelectSource, moveToDestination, chooseIntermediatePath, cancelPendingPathChoice, closeEndGameOverlay, handleUndo, handleNewGame, handleResetPosition, clearSavedGame,
     toggleDebug, updateDebugDie
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -212,6 +212,10 @@ button:focus-visible {
   min-width: 0;
 }
 
+.game-layout-overlay-open {
+  filter: brightness(0.82);
+}
+
 .pip-row {
   grid-column: 1;
   grid-row: 1;
@@ -296,6 +300,54 @@ button:focus-visible {
     linear-gradient(180deg, rgba(255, 245, 228, 0.23), rgba(0, 0, 0, 0.22)),
     linear-gradient(145deg, var(--wood-light), var(--wood-mid) 46%, var(--wood-dark));
   box-shadow: 0 10px 18px rgba(45, 25, 10, 0.25);
+}
+
+.endgame-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 20;
+  animation: endgameOverlayIn 220ms ease-out;
+}
+
+.endgame-overlay-card {
+  width: min(92%, 360px);
+  border-radius: 0.9rem;
+  border: 2px solid #6f4d30;
+  background: linear-gradient(180deg, #efe0c4, #dfc59c);
+  color: #2f2217;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+  padding: 1rem 1rem 0.9rem;
+  text-align: center;
+}
+
+.endgame-overlay-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.endgame-overlay-card p {
+  margin: 0.45rem 0 0;
+  font-size: 0.95rem;
+}
+
+.endgame-overlay-actions {
+  margin-top: 0.85rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.endgame-overlay-actions .button-primary {
+  background: #3b79d9;
+  border-color: #2f65b8;
+  color: #fff;
+}
+
+.endgame-overlay-actions .button-secondary {
+  background: #e6d9c1;
+  color: #2f2217;
 }
 
 .pip-box {
@@ -782,6 +834,18 @@ button:focus-visible {
   }
 }
 
+@keyframes endgameOverlayIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .bearoff-tray.legal,
 .bearoff-tray.is-legal {
   border: 3px solid #F2C572;
@@ -830,6 +894,10 @@ button:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .endgame-overlay {
+    animation: none;
+  }
+
   .point.selected .checker-stack,
   .point.is-selected .checker-stack,
   .barForcedSelected .bar-checker:first-child,


### PR DESCRIPTION
### Motivation
- Improve the end-of-game UX by surfacing a focused, centered overlay when a winner is determined so the outcome and next actions are clear.
- Keep the final board visible behind the overlay and prevent normal gameplay interactions while the overlay is open.
- Provide immediate actions: `Play Again` to start a fresh game and `Review Board` to dismiss the overlay and leave the final board as-is, plus a quick, restrained entrance animation.

### Description
- Add `isEndGameOverlayOpen` state and a `closeEndGameOverlay` action in `useGameController` and open the overlay automatically when `game.winner` is set, and clear it when starting/resetting a game (`src/hooks/useGameController.js`).
- Render a compact centered overlay card in `BoardSurface` that displays winner-specific copy and the two actions; wire `Play Again` to `handleNewGame` and `Review Board` to `closeEndGameOverlay`, and guard board interactions while the overlay is shown (`src/components/board/BoardSurface.jsx`).
- Add styling and a subtle 220ms fade/scale-in animation plus reduced-motion support and a mild background dim (`.game-layout-overlay-open`, `.endgame-overlay`, `@keyframes endgameOverlayIn`) to match the app theme (`src/styles.css`).
- Add UI tests that assert the overlay appears for both player and computer wins and that the `Review Board` and `Play Again` actions behave as expected (`src/__tests__/App.endgame-overlay.test.jsx`).

### Testing
- Attempted a production build with `npm run build`, which failed in this environment due to unresolved vendored imports (`react-helmet-async` / `react-router-dom`) unrelated to these changes and present in the project setup. (failure)
- Attempted to run the new UI test using `npx vitest run src/__tests__/App.endgame-overlay.test.jsx`, but test execution could not proceed because fetching `vitest` from the npm registry is blocked (HTTP 403) in this environment. (failure)
- Tried to capture a runtime screenshot via Playwright to validate the overlay visually, but the Chromium process crashed in the container so no snapshot was produced. (failure)
- The test file and UI assertions were added and reviewed; automated execution could not be completed here due to environment dependency/network limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b45d500608832e894e0f0b170d6e01)