### PR TITLE
Stabilize status message area to prevent layout shift

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -211,7 +211,9 @@ export default function BoardSurface(props) {
         <div className={`board-ui-row ${isEndGameOverlayOpen ? 'board-centered-status-controls-hidden' : ''}`.trim()}>
           <div className="board-centered-status-controls">
             {toastMessage && <section className="roll-toast" aria-live="polite">{toastMessage}</section>}
-            <section className="roll-toast" aria-live="polite">{statusMessage}</section>
+            <div className="status-region">
+              <section className="roll-toast status-message" aria-live="polite">{statusMessage}</section>
+            </div>
             <ControlsPanel
               isAnimatingMove={isAnimatingMove}
               isAnyRollAnimationRunning={isAnyRollAnimationRunning}

--- a/src/styles.css
+++ b/src/styles.css
@@ -231,6 +231,21 @@ button:focus-visible {
   box-shadow: 0 4px 10px rgba(45, 25, 10, 0.16);
 }
 
+.status-region {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc((0.9rem * 1.35 * 2) + (0.55rem * 2) + 4px);
+}
+
+.status-message {
+  width: min(90%, 480px);
+  max-width: min(90%, 480px);
+  text-align: center;
+  line-height: 1.35;
+}
+
 .controls {
   margin-top: 0.4rem;
   display: flex;
@@ -1225,6 +1240,11 @@ button:focus-visible {
   .board-centered-status-controls {
     margin-top: 0.75rem;
     gap: 0.45rem;
+  }
+
+  .status-message {
+    width: min(88vw, 480px);
+    max-width: min(88vw, 480px);
   }
 
   .pip-row {


### PR DESCRIPTION
### Motivation
- The status message could wrap from one to two lines and cause the controls and content below to jump vertically, creating a jarring visual shift.
- The intent is a pure layout/CSS fix to reserve enough vertical space for normal two-line status messages while preserving the existing visual style of the status pill.

### Description
- Wrapped the existing status message in a dedicated container by adding a `div.status-region` around the status in `src/components/board/BoardSurface.jsx` so the status has a stable layout slot.
- Added CSS for `.status-region` to center the message and reserve a `min-height` sized to hold two lines of normal text while vertically centering one-line messages in `src/styles.css`.
- Added `.status-message` rules to constrain message width (`min(90%, 480px)` on desktop and a mobile override) so long messages wrap predictably without affecting layout, while preserving the original `.roll-toast` visuals.
- Kept all game logic and message text unchanged; this is layout-only and scoped to the status area.

### Testing
- Built the project with `npm run build` and the build completed successfully.
- Launched the dev server with `npm run dev` and captured automated desktop and mobile screenshots via a Playwright script to visually validate the stable status area.
- No automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56928d36c832ebe511fa405afd540)