### PR TITLE
Animate committed checker moves in a single straight-line transform

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -236,7 +236,7 @@ export default function BoardSurface(props) {
           </div>
         </div>
       )}
-      {movingChecker && <span aria-hidden="true" className={`checker moving-checker checker-${movingChecker.player === 'B' ? 'b' : 'a'}`} style={{ left: `${movingChecker.x}px`, top: `${movingChecker.y}px`, '--move-step-ms': `${moveStepMs}ms` }} />}
+      {movingChecker && <span aria-hidden="true" className={`checker moving-checker checker-${movingChecker.player === 'B' ? 'b' : 'a'} ${movingChecker.isMoving ? 'is-moving' : ''}`} style={{ left: `${movingChecker.x}px`, top: `${movingChecker.y}px`, '--move-step-ms': `${moveStepMs}ms`, '--move-dx': `${movingChecker.dx ?? 0}px`, '--move-dy': `${movingChecker.dy ?? 0}px` }} />}
     </section>
   );
 }

--- a/src/hooks/useGameController.js
+++ b/src/hooks/useGameController.js
@@ -23,7 +23,7 @@ import {
   findDeterministicChoice
 } from './movePathChoice.js';
 
-const MOVE_STEP_MS = 210;
+const MOVE_ANIMATION_MS = 220;
 const MOVE_START_DELAY_MS = 40;
 const HIT_TO_BAR_MS = 220;
 const BOARD_DICE_ROLL_MS = 1000;
@@ -273,25 +273,6 @@ export default function useGameController({ clock = defaultClock, media = defaul
     if (location === 'off') return bearOffRefs.current[playerForOff] ?? null;
     return pointRefs.current.get(location) ?? null;
   }
-  function pathForMove(stateAtMove, move) {
-    const path = [move.from];
-    const player = stateAtMove.currentPlayer;
-    if (typeof move.from === 'number' && typeof move.to === 'number') {
-      const dir = move.to > move.from ? 1 : -1;
-      for (let p = move.from + dir; p !== move.to + dir; p += dir) path.push(p);
-      return path;
-    }
-    if (typeof move.from === 'number' && move.to === 'off') {
-      const dir = player === PLAYER_A ? -1 : 1;
-      for (let step = 1; step <= move.dieUsed; step += 1) {
-        const point = move.from + dir * step;
-        if (point < 0 || point > 23) return [...path, 'off'];
-        path.push(point);
-      }
-      return [...path, 'off'];
-    }
-    return [...path, move.to];
-  }
   function topCheckerElementForPoint(point) {
     const pointElement = pointRefs.current.get(point);
     if (!pointElement) return null;
@@ -387,14 +368,27 @@ export default function useGameController({ clock = defaultClock, media = defaul
   }
   async function animateSingleMove(stateAtMove, move) {
     const player = stateAtMove.currentPlayer;
-    const centers = pathForMove(stateAtMove, move).map((loc) => centerFromElement(elementForLocation(loc, player))).filter(Boolean);
-    if (centers.length < 2) return;
-    setMovingChecker({ player, x: centers[0].x, y: centers[0].y });
+    const sourceCenter = centerFromElement(elementForLocation(move.from, player));
+    const destinationCenter = centerFromElement(elementForLocation(move.to, player));
+    if (!sourceCenter || !destinationCenter) return;
+    setMovingChecker({
+      player,
+      x: sourceCenter.x,
+      y: sourceCenter.y,
+      dx: 0,
+      dy: 0,
+      isMoving: false
+    });
     await clock.wait(MOVE_START_DELAY_MS);
-    for (let i = 1; i < centers.length; i += 1) {
-      setMovingChecker((prev) => (prev ? { ...prev, x: centers[i].x, y: centers[i].y } : prev));
-      await clock.wait(MOVE_STEP_MS);
-    }
+    setMovingChecker((prev) => (prev
+      ? {
+        ...prev,
+        dx: destinationCenter.x - sourceCenter.x,
+        dy: destinationCenter.y - sourceCenter.y,
+        isMoving: true
+      }
+      : prev));
+    await clock.wait(MOVE_ANIMATION_MS);
     await clock.wait(30);
   }
   async function performMoveSequence(stateAtMove, moves) {
@@ -633,7 +627,7 @@ export default function useGameController({ clock = defaultClock, media = defaul
   return {
     game, gamePhase, openingMessage, statusMessage, playerPipCount, computerPipCount, canPlayerRoll, isComputerTurn, isAnimatingMove,
     isAnyRollAnimationRunning, diceAnimKey, pendingRoll, disableUsedDiceStyling, toastMessage, movingChecker,
-    activeSelectedSource, destinationSet, movableSourceSet, showMovableSources, moveStepMs: MOVE_STEP_MS,
+    activeSelectedSource, destinationSet, movableSourceSet, showMovableSources, moveStepMs: MOVE_ANIMATION_MS,
     pendingPathChoices, pendingIntermediateSet, isEndGameOverlayOpen,
     hiddenHitCheckers, pendingBarHits,
     boardStageRef, pointRefs, barRef, bearOffRefs,

--- a/src/styles.css
+++ b/src/styles.css
@@ -833,10 +833,12 @@ button:focus-visible {
   left: 0;
   top: 0;
   transform: translate(-50%, -50%);
-  transition:
-    left var(--move-step-ms, 210ms) linear,
-    top var(--move-step-ms, 210ms) linear;
-  will-change: left, top;
+  transition: transform var(--move-step-ms, 220ms) ease-out;
+  will-change: transform;
+}
+
+.moving-checker.is-moving {
+  transform: translate(calc(-50% + var(--move-dx, 0px)), calc(-50% + var(--move-dy, 0px)));
 }
 
 .selected,


### PR DESCRIPTION
### Motivation
- The visual movement for committed checker moves should be a single, smooth straight-line animation from the source to the final destination, improving polish and performance without changing game logic.

### Description
- Replace stepwise position updates with a single transform-based animation by computing the source and final destination centers in `animateSingleMove` and driving a one-shot translation over ~220ms using `transform` instead of repeatedly setting `left`/`top`.
- Pass translation deltas to the overlay via `movingChecker.dx`/`movingChecker.dy` and an `is-moving` flag, and update the board render (`BoardSurface`) to expose `--move-dx`/`--move-dy` and `--move-step-ms` CSS variables for the transform transition.
- Update CSS for `.moving-checker` to transition `transform` with `ease-out` and `var(--move-step-ms)` for smooth, performant motion and to avoid layout-driven stepping.
- Changed animation-only code paths: `animateSingleMove` and the moving checker overlay/CSS; `animateHitCheckerToBar` / `animateCheckerToBar` remain untouched so hit-to-bar animations are still separate, and no game/rules logic was modified (`applyMove`, legal move generation, hit detection, dice usage, and path-choice flows are unchanged).

### Testing
- Ran unit test runner command `npx vitest run src/__tests__/App.move-selection.test.jsx`, which failed due to the environment being unable to download `vitest` from the registry (network/registry restriction), so tests could not be executed here.
- Ran `npm run build`, which failed because local dependency imports (`react-helmet-async`, `react-router-dom`) are not resolvable in this environment, preventing a successful production build.
- Started the dev server with `npm run dev` and captured a browser screenshot from the running app endpoint to validate the UI changes visually, but several imports remained unresolved in this environment; the dev server did start and a screenshot artifact was collected successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b57f5d9a5c832ea179c6972b8f73a0)