### PR TITLE
Use player-facing wording in status messages and update no-moves/win text

### DIFF
--- a/src/__tests__/App.move-selection.test.jsx
+++ b/src/__tests__/App.move-selection.test.jsx
@@ -39,7 +39,7 @@ function buildSingleClickScenario() {
     openingRollPending: false,
     openingRoll: { player: 6, computer: 1, status: 'done' },
     undoStack: [],
-    statusText: 'Player rolled 6 and 1.',
+    statusText: 'You rolled 6 and 1.',
     dev: { debugOpen: false, dieA: 1, dieB: 1 }
   };
 }
@@ -61,7 +61,7 @@ function buildChainClickScenario() {
     openingRollPending: false,
     openingRoll: { player: 6, computer: 1, status: 'done' },
     undoStack: [],
-    statusText: 'Player rolled 5 and 6.',
+    statusText: 'You rolled 5 and 6.',
     dev: { debugOpen: false, dieA: 1, dieB: 1 }
   };
 }
@@ -83,7 +83,7 @@ function buildDoubleOnesChainScenario() {
     openingRollPending: false,
     openingRoll: { player: 6, computer: 1, status: 'done' },
     undoStack: [],
-    statusText: 'Player rolled 1 and 1.',
+    statusText: 'You rolled 1 and 1.',
     dev: { debugOpen: false, dieA: 1, dieB: 1 }
   };
 }
@@ -108,7 +108,7 @@ function buildAmbiguousPathScenario() {
     openingRollPending: false,
     openingRoll: { player: 6, computer: 1, status: 'done' },
     undoStack: [],
-    statusText: 'Player rolled 1 and 2.',
+    statusText: 'You rolled 1 and 2.',
     dev: { debugOpen: false, dieA: 1, dieB: 1 }
   };
 }
@@ -281,7 +281,7 @@ describe('App move selection', () => {
     expect(screen.getAllByText('Choose which blot to hit').at(-1)).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
-    expect(screen.getAllByText('Player rolled 1 and 2.').at(-1)).toBeInTheDocument();
+    expect(screen.getAllByText('You rolled 1 and 2.').at(-1)).toBeInTheDocument();
   });
 
   it('keeps a hit blot hidden on its original point while intermediate-step path resolution animates', async () => {

--- a/src/__tests__/App.turn-flow.characterization.test.jsx
+++ b/src/__tests__/App.turn-flow.characterization.test.jsx
@@ -48,7 +48,7 @@ describe('App turn-flow characterization', () => {
       openingRollPending: false,
       openingRoll: { player: 6, computer: 1, status: 'done' },
       undoStack: [],
-      statusText: 'Player to move. Roll dice.',
+      statusText: 'Your turn. Roll the dice.',
       dev: { debugOpen: false, dieA: 6, dieB: 5 }
     }));
   }
@@ -86,7 +86,7 @@ describe('App turn-flow characterization', () => {
 
     await vi.advanceTimersByTimeAsync(1000);
 
-    expect(screen.getAllByText(/You rolled 6 and 5\. No legal moves\. Turn passes to computer\./i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/You rolled 6 and 5\. You have no legal moves\. Turn passes to the computer\./i).length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: 'Roll Dice' })).toBeDisabled();
     expect(screen.queryByText(/Computer rolled/i)).not.toBeInTheDocument();
 
@@ -98,6 +98,6 @@ describe('App turn-flow characterization', () => {
     expect(screen.getAllByText(/No legal moves\./i).length).toBeGreaterThan(0);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(screen.getByText(/Turn passed to computer\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Computer's turn\. Rolling dice\.\.\./i)).toBeInTheDocument();
   });
 });

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -313,7 +313,7 @@ export function applyMove(state, move) {
   let next = applyMoveInternal(state, move);
 
   if (next.winner) {
-    return withStatus(next, `${playerLabel(next.currentPlayer)} wins.`);
+    return withStatus(next, next.currentPlayer === PLAYER_A ? 'You win!' : 'Computer wins.');
   }
 
   const remainingLegal = computeLegalMoves(next);
@@ -388,12 +388,14 @@ export function rollDice(state, forcedValues = null, options = {}) {
       values: [d1, d2],
       remaining
     },
-    statusText: `${playerLabel(state.currentPlayer)} rolled ${d1} and ${d2}.`
+    statusText: `${state.currentPlayer === PLAYER_A ? 'You' : 'Computer'} rolled ${d1} and ${d2}.`
   };
 
   if (computeLegalMoves(next).length === 0) {
     if (autoPassNoMoves) {
-      next = endTurn(next, `${playerLabel(state.currentPlayer)} rolled ${d1} and ${d2} but has no legal moves. Turn passed.`);
+      next = endTurn(next, state.currentPlayer === PLAYER_A
+        ? `You rolled ${d1} and ${d2}. You have no legal moves. Turn passes to the computer.`
+        : `Computer rolled ${d1} and ${d2}. Computer has no legal moves. Your turn.`);
     } else {
       next = {
         ...next,
@@ -401,7 +403,9 @@ export function rollDice(state, forcedValues = null, options = {}) {
           values: [d1, d2],
           remaining: []
         },
-        statusText: `${playerLabel(state.currentPlayer)} rolled ${d1} and ${d2} but has no legal moves.`
+        statusText: state.currentPlayer === PLAYER_A
+          ? `You rolled ${d1} and ${d2}. You have no legal moves.`
+          : `Computer rolled ${d1} and ${d2}. Computer has no legal moves.`
       };
     }
   }
@@ -415,7 +419,7 @@ export function endTurn(state, statusTextOverride = null) {
     ...cloneState(state),
     currentPlayer: nextPlayer,
     dice: { values: [], remaining: [] },
-    statusText: statusTextOverride ?? `${playerLabel(nextPlayer)} to move. Roll dice.`
+    statusText: statusTextOverride ?? (nextPlayer === PLAYER_A ? 'Your turn. Roll the dice.' : "Computer's turn. Rolling dice...")
   };
 }
 

--- a/src/hooks/useGameController.js
+++ b/src/hooks/useGameController.js
@@ -227,7 +227,7 @@ export default function useGameController({ clock = defaultClock, media = defaul
 
   useEffect(() => {
     if (gamePhase === 'OPENING_ROLL' || game.winner || game.currentPlayer !== PLAYER_A || playerTurnPhase !== 'NO_MOVES_NOTICE') return;
-    const noMovesMessage = `You rolled ${game.dice.values[0]} and ${game.dice.values[1]}. No legal moves. Turn passes to computer.`;
+    const noMovesMessage = `You rolled ${game.dice.values[0]} and ${game.dice.values[1]}. You have no legal moves. Turn passes to the computer.`;
     setGame((prev) => {
       if (
         prev.winner
@@ -240,7 +240,7 @@ export default function useGameController({ clock = defaultClock, media = defaul
       return { ...prev, statusText: noMovesMessage };
     });
     const timer = clock.setTimeout(() => {
-      setGame((prev) => prev.winner || prev.currentPlayer !== PLAYER_A || prev.dice.values.length !== 2 || prev.dice.remaining.length !== 0 || computeLegalMoves(prev).length !== 0 ? prev : pushUndoState(prev, endTurn(prev, `Player rolled ${prev.dice.values[0]} and ${prev.dice.values[1]}. No legal moves. Turn passed to computer.`)));
+      setGame((prev) => prev.winner || prev.currentPlayer !== PLAYER_A || prev.dice.values.length !== 2 || prev.dice.remaining.length !== 0 || computeLegalMoves(prev).length !== 0 ? prev : pushUndoState(prev, endTurn(prev, `You rolled ${prev.dice.values[0]} and ${prev.dice.values[1]}. You have no legal moves. Turn passes to the computer.`)));
       setPlayerTurnPhase('NEED_ROLL');
     }, PLAYER_NO_MOVES_NOTICE_MS);
     return () => clock.clearTimeout(timer);
@@ -590,7 +590,7 @@ export default function useGameController({ clock = defaultClock, media = defaul
       if (computerTurnInFlightRef.current) return;
       if (game.dice.values.length === 2 && game.dice.remaining.length === 0 && computeLegalMoves(game).length === 0) {
         const [rolledA, rolledB] = game.dice.values;
-        setGame((prev) => prev.currentPlayer !== PLAYER_B || prev.dice.values.length !== 2 || prev.dice.remaining.length !== 0 ? prev : pushUndoState(prev, endTurn(prev, `Computer rolled ${rolledA} and ${rolledB} but has no legal moves. Turn passed.`)));
+        setGame((prev) => prev.currentPlayer !== PLAYER_B || prev.dice.values.length !== 2 || prev.dice.remaining.length !== 0 ? prev : pushUndoState(prev, endTurn(prev, `Computer rolled ${rolledA} and ${rolledB}. Computer has no legal moves. Your turn.`)));
         setToastMessage(null); return;
       }
       if (game.dice.remaining.length === 0) {
@@ -613,9 +613,9 @@ export default function useGameController({ clock = defaultClock, media = defaul
           setPendingRoll((prev) => (prev?.id === rollId ? null : prev)); setIsAnimatingRoll(false);
           if (computerTurnSequenceIdRef.current !== sequenceId || !committed) return;
           if (computeLegalMoves(committed).length === 0) {
-            setToastMessage(`Computer rolled ${d1} and ${d2} — no legal moves.`); await clock.wait(700);
+            setToastMessage(`Computer rolled ${d1} and ${d2}. Computer has no legal moves.`); await clock.wait(700);
             if (computerTurnSequenceIdRef.current !== sequenceId) return;
-            setGame((prev) => prev.winner || prev.currentPlayer !== PLAYER_B ? prev : pushUndoState(prev, endTurn(prev, `Computer rolled ${d1} and ${d2} but has no legal moves. Turn passed.`)));
+            setGame((prev) => prev.winner || prev.currentPlayer !== PLAYER_B ? prev : pushUndoState(prev, endTurn(prev, `Computer rolled ${d1} and ${d2}. Computer has no legal moves. Your turn.`)));
             setToastMessage(null);
           }
         })().finally(() => {


### PR DESCRIPTION
### Motivation
- Make status and toast messages address the human player directly and provide clearer phrasing for no-moves and turn transitions.
- Ensure win and turn prompts are explicit and natural in the UI (e.g. distinguishing between "You" and "Computer").

### Description
- Replace generic `playerLabel`-based messages with player-facing strings in `rollDice`, `applyMove`, and `endTurn` so status text uses `You`/`Computer` and clearer no-moves phrasing.
- Update `useGameController` timers and no-moves handling to set matching messages when pausing before passing the turn and when auto-passing the computer's no-moves situation.
- Adjusted toasted messages for computer no-moves and other UI messages to match the new wording.
- Updated tests in `src/__tests__/App.move-selection.test.jsx` and `src/__tests__/App.turn-flow.characterization.test.jsx` to expect the revised phrasing.

### Testing
- Updated unit tests in `src/__tests__/App.move-selection.test.jsx` and `src/__tests__/App.turn-flow.characterization.test.jsx` to match new messages and ran the test suite; all automated tests passed.
- Verified the changed code paths for `rollDice`, `applyMove`, and `endTurn` through the modified tests which assert the new status strings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5842edc58832e8553f2c36a5722da)