### PR TITLE
Add `PIP:` prefix to board pip-count boxes

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -171,11 +171,11 @@ export default function BoardSurface(props) {
           <div className="pip-row" aria-label="Pip counts">
             <div className={`pip-box pip-box-computer ${!game.winner && isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
               <span className="pip-box-label">Computer</span>
-              <span className="pip-box-value">{computerPipCount}</span>
+              <span className="pip-box-value">PIP: {computerPipCount}</span>
             </div>
             <div className={`pip-box pip-box-player ${!game.winner && !isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
               <span className="pip-box-label">Player</span>
-              <span className="pip-box-value">{playerPipCount}</span>
+              <span className="pip-box-value">PIP: {playerPipCount}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Make the pip-count display above the board explicit by prepending `PIP: ` to both the Computer and Player pip values for clearer UI context.

### Description
- Update `src/components/board/BoardSurface.jsx` to render `PIP: {computerPipCount}` and `PIP: {playerPipCount}` in the pip-count boxes above the board.

### Testing
- Ran `npm run build` which completed successfully.
- Executed an automated Playwright script to capture a screenshot of the updated UI (artifact `pip-prefix.png`), which ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b8ff360c832ebf8d5d7dcda1eeab)