### PR TITLE
Keep pip box values on one line

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -463,6 +463,7 @@ button:focus-visible {
   font-weight: 700;
   line-height: 1;
   margin-left: auto;
+  white-space: nowrap;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
### Motivation
- Prevent pip values from wrapping in the pip boxes so labels like `PIP: <number>` stay on a single line at desktop widths.

### Description
- Add `white-space: nowrap;` to `.pip-box-value` in `src/styles.css` while preserving `font-variant-numeric: tabular-nums;` to keep numeric width stable.

### Testing
- Ran `npm run build` (passed) and executed a Playwright check at `1440x900` which confirmed `.pip-box-value` computes `white-space: nowrap` and both Computer and Player pip boxes display their values without wrapping (`scrollWidth === clientWidth`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ba624948832eaa193ba5872f36a7)