### PR TITLE
Refactor pip count prefix and number styling

### DIFF
--- a/src/components/board/BoardSurface.jsx
+++ b/src/components/board/BoardSurface.jsx
@@ -171,11 +171,17 @@ export default function BoardSurface(props) {
           <div className="pip-row" aria-label="Pip counts">
             <div className={`pip-box pip-box-computer ${!game.winner && isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
               <span className="pip-box-label">Computer</span>
-              <span className="pip-box-value">{computerPipCount}</span>
+              <span className="pip-box-value">
+                <span className="pip-prefix">PIP:</span>
+                <span className="pip-count">{computerPipCount}</span>
+              </span>
             </div>
             <div className={`pip-box pip-box-player ${!game.winner && !isComputerTurn ? 'pip-box-active' : ''}`.trim()}>
               <span className="pip-box-label">Player</span>
-              <span className="pip-box-value">{playerPipCount}</span>
+              <span className="pip-box-value">
+                <span className="pip-prefix">PIP:</span>
+                <span className="pip-count">{playerPipCount}</span>
+              </span>
             </div>
           </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -459,12 +459,26 @@ button:focus-visible {
 }
 
 .pip-box-value {
-  font-size: 22px;
-  font-weight: 700;
-  line-height: 1;
   margin-left: auto;
   white-space: nowrap;
   text-align: right;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.28rem;
+  line-height: 1;
+}
+
+.pip-prefix {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  opacity: 0.9;
+}
+
+.pip-count {
+  font-size: 22px;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
 
@@ -1134,7 +1148,11 @@ button:focus-visible {
     font-size: 10px;
   }
 
-  .pip-box-value {
+  .pip-prefix {
+    font-size: 9px;
+  }
+
+  .pip-count {
     font-size: clamp(18px, 4.8vw, 20px);
   }
 
@@ -1262,7 +1280,11 @@ button:focus-visible {
     font-size: 9px;
   }
 
-  .pip-box-value {
+  .pip-prefix {
+    font-size: 8px;
+  }
+
+  .pip-count {
     font-size: clamp(17px, 4.9vw, 18px);
   }
 


### PR DESCRIPTION
### Motivation
- Provide distinct styling for the pip label and numeric value so the prefix and number can be styled independently and aligned reliably across responsive states.

### Description
- Updated pip markup in `src/components/board/BoardSurface.jsx` to wrap counts as `<span className="pip-box-value"><span className="pip-prefix">PIP:</span> <span className="pip-count">{...}</span></span>` for both Computer and Player boxes.
- Converted `.pip-box-value` to an inline flex container with `display: inline-flex`, `align-items: baseline`, and a small `gap` so the prefix and number align stably.
- Added `.pip-prefix` and `.pip-count` rules to `src/styles.css` where `.pip-prefix` is smaller, medium weight, uppercase with tracking, and `.pip-count` is larger, bold, and uses `font-variant-numeric: tabular-nums`.
- Added responsive font-size adjustments for `.pip-prefix` and `.pip-count` inside existing mobile breakpoints to preserve visual consistency for active and inactive pip boxes.

### Testing
- Ran `npm install` which completed successfully.
- Built the production bundle with `npm run build` which completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and captured a full-page screenshot for visual verification which confirmed alignment and consistency across active/inactive pip boxes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5bb69b200832e9254d0e968c24da4)