### PR TITLE
Add favicon and webmanifest links to HTML head

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="shortcut icon" href="/favicon.ico" />
     <title>Backgammon</title>
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- Ensure the favicon and PWA metadata files placed in `public/` are discovered by browsers and devices by adding the appropriate link tags to the application HTML.

### Description
- Added link tags to `index.html` for `apple-touch-icon.png`, `favicon-32x32.png`, `favicon-16x16.png`, `favicon.ico`, and `site.webmanifest` so the files in `/public` are referenced from the document head.

### Testing
- Ran `npm run build`, which completed Vite transform steps but failed due to an existing dependency resolution issue where Rollup/Vite cannot resolve `react-helmet-async` from `src/main.jsx` (failure is unrelated to the favicon/manifest changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b9056798832eb0228bc5fc867c19)