### PR TITLE
Adjust homepage spacing between status message, controls, and content

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -249,7 +249,7 @@ button:focus-visible {
 }
 
 .controls {
-  margin-top: 1.6rem;
+  margin-top: 0.55rem;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -1304,7 +1304,7 @@ button:focus-visible {
   }
 
   .controls {
-    margin-top: 1.35rem;
+    margin-top: 0.45rem;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.45rem;
@@ -1544,7 +1544,7 @@ button:focus-visible {
 }
 
 .home-content-stack {
-  margin-top: 0.7rem;
+  margin-top: 2.3rem;
 }
 
 .home-content-stack section + section {


### PR DESCRIPTION
### Motivation
- Reduce the vertical gap between the in-game status message and the New Game/Undo controls, and add more separation between the embedded game controls and the homepage content block that begins with `Play Backgammon Instantly` for better visual balance on desktop and mobile.

### Description
- CSS-only changes in `src/styles.css` adjusting `.controls` top margin from `1.6rem` to `0.55rem`, the mobile `.controls` top margin from `1.35rem` to `0.45rem`, and increasing `.home-content-stack` top margin from `0.7rem` to `2.3rem`.

### Testing
- Ran `npm install` successfully.
- Ran `npm run build` successfully and verified the production build completed.
- Launched the dev server and captured an automated page screenshot with Playwright; the Chromium headless attempt crashed in this environment but a Firefox-based run completed and produced the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6bf995ce0832ea7d6e938b679816f)