### PR TITLE
Add Google Analytics (gtag) and SPA page-view tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VCLXS3979T"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VCLXS3979T', { send_page_view: false });
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,54 @@
+const GA_MEASUREMENT_ID = 'G-VCLXS3979T';
+
+function trackPageView() {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return;
+  }
+
+  window.gtag('event', 'page_view', {
+    send_to: GA_MEASUREMENT_ID,
+    page_path: window.location.pathname,
+    page_location: window.location.href,
+    page_title: document.title,
+  });
+}
+
+export function installGaPageTracking() {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  let lastPathname = null;
+
+  const sendIfPathChanged = () => {
+    const { pathname } = window.location;
+    if (pathname === lastPathname) {
+      return;
+    }
+
+    lastPathname = pathname;
+    trackPageView();
+  };
+
+  const originalPushState = window.history.pushState;
+  const originalReplaceState = window.history.replaceState;
+
+  window.history.pushState = function patchedPushState(...args) {
+    originalPushState.apply(this, args);
+    sendIfPathChanged();
+  };
+
+  window.history.replaceState = function patchedReplaceState(...args) {
+    originalReplaceState.apply(this, args);
+    sendIfPathChanged();
+  };
+
+  window.addEventListener('popstate', sendIfPathChanged);
+  sendIfPathChanged();
+
+  return () => {
+    window.history.pushState = originalPushState;
+    window.history.replaceState = originalReplaceState;
+    window.removeEventListener('popstate', sendIfPathChanged);
+  };
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import AppRouter from './router/AppRouter.jsx';
+import { installGaPageTracking } from './analytics.js';
 import './styles.css';
+
+
+function AnalyticsTracker() {
+  useEffect(() => installGaPageTracking(), []);
+  return null;
+}
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HelmetProvider>
+      <AnalyticsTracker />
       <AppRouter />
     </HelmetProvider>
   </React.StrictMode>


### PR DESCRIPTION
### Motivation

- Integrate Google Analytics to capture page views for the single-page application.
- Ensure page-view events are only sent when route changes occur to avoid duplicate automatic `page_view` events.

### Description

- Added the `gtag.js` snippet to `index.html` with measurement ID `G-VCLXS3979T` and `send_page_view: false` to prevent automatic page_view dispatch.
- Introduced `src/analytics.js` which exports `installGaPageTracking` and a `trackPageView` helper that calls `gtag('event', 'page_view', ...)` with `page_path`, `page_location`, and `page_title` and no-ops when `window` or `gtag` is not available.
- Implemented SPA-aware tracking by patching `history.pushState` and `history.replaceState` and listening to the `popstate` event to detect route changes, with a cleanup function that restores originals and removes the listener.
- Wire-up in `src/main.jsx` by adding an `AnalyticsTracker` component that calls `installGaPageTracking` inside a `useEffect` and is rendered inside the app root.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7157680c0832e9386b7c0020aaf6f)