### PR TITLE
Add centralized GA4 gameplay event tracking

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,11 +1,60 @@
 const GA_MEASUREMENT_ID = 'G-VCLXS3979T';
 
-function trackPageView() {
+/**
+ * @typedef {Object} CheckerMoveEventParams
+ * @property {number|string} [from_point]
+ * @property {number|string} [to_point]
+ * @property {number} [die_value]
+ * @property {boolean} [is_hit]
+ * @property {boolean} [is_bear_off]
+ * @property {boolean} [from_bar]
+ * @property {number} [remaining_dice_count]
+ */
+
+function getGtag() {
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return null;
+  }
+
+  return window.gtag;
+}
+
+export function trackEvent(eventName, params = {}) {
+  const gtag = getGtag();
+  if (!gtag) {
     return;
   }
 
-  window.gtag('event', 'page_view', {
+  gtag('event', eventName, {
+    send_to: GA_MEASUREMENT_ID,
+    ...params,
+  });
+}
+
+export function trackRollDice() {
+  trackEvent('roll_dice');
+}
+
+export function trackNewGame() {
+  trackEvent('new_game');
+}
+
+export function trackUndoMove() {
+  trackEvent('undo_move');
+}
+
+/** @param {CheckerMoveEventParams} params */
+export function trackCheckerMove(params) {
+  trackEvent('checker_move', params);
+}
+
+function trackPageView() {
+  const gtag = getGtag();
+  if (!gtag) {
+    return;
+  }
+
+  gtag('event', 'page_view', {
     send_to: GA_MEASUREMENT_ID,
     page_path: window.location.pathname,
     page_location: window.location.href,

--- a/src/hooks/useGameController.js
+++ b/src/hooks/useGameController.js
@@ -17,6 +17,7 @@ import * as defaultMedia from '../platform/media.js';
 import * as defaultRandom from '../platform/random.js';
 import * as defaultStorage from '../platform/storage.js';
 import { clearSavedGameState, loadGameState, saveGameState } from '../services/persistence.js';
+import { trackCheckerMove, trackNewGame, trackRollDice, trackUndoMove } from '../analytics.js';
 import {
   analyzePathChoices,
   buildMoveSequenceOption,
@@ -418,7 +419,29 @@ export default function useGameController({ clock = defaultClock, media = defaul
       setMovingChecker(null);
       setIsAnimatingMove(false);
     }
-    setGame((prev) => (prev !== stateAtMove ? prev : pushUndoState(prev, applyMoveSequence(prev, moves))));
+
+    const firstMove = moves[0];
+    const finalMove = moves[moves.length - 1];
+    const totalDieValue = moves.reduce((sum, move) => sum + move.dieUsed, 0);
+    const isHit = moves.some((move) => move.hit);
+
+    setGame((prev) => {
+      if (prev !== stateAtMove) return prev;
+      const committed = applyMoveSequence(prev, moves);
+      // Fire once at committed state update so path-choice/internal steps only emit one human move event.
+      if (stateAtMove.currentPlayer === PLAYER_A && firstMove && finalMove) {
+        trackCheckerMove({
+          from_point: firstMove.from,
+          to_point: finalMove.to,
+          die_value: totalDieValue,
+          is_hit: isHit,
+          is_bear_off: finalMove.to === 'off',
+          from_bar: firstMove.from === 'bar',
+          remaining_dice_count: committed.dice.remaining.length
+        });
+      }
+      return pushUndoState(prev, committed);
+    });
     setHiddenHitCheckers([]);
     setPendingBarHits({ A: 0, B: 0 });
   }
@@ -493,6 +516,8 @@ export default function useGameController({ clock = defaultClock, media = defaul
     if (isAnimatingMove) return;
     resetFlowState();
     setIsEndGameOverlayOpen(false);
+    // Fire only when the user starts a fresh game from the New Game control.
+    trackNewGame();
     setGame((prev) => pushUndoState(prev, createInitialState()));
   }
   function handleResetPosition() {
@@ -505,7 +530,12 @@ export default function useGameController({ clock = defaultClock, media = defaul
     if (isAnimatingMove) return;
     resetFlowState();
     setIsEndGameOverlayOpen(false);
-    setGame((prev) => undo(prev));
+    setGame((prev) => {
+      if (!prev.undoStack.length) return prev;
+      // Fire only when Undo actually pops state, preventing no-op click tracking.
+      trackUndoMove();
+      return undo(prev);
+    });
   }
   function clearSavedGame() {
     if (isAnimatingMove) return;
@@ -565,6 +595,10 @@ export default function useGameController({ clock = defaultClock, media = defaul
 
   function handleRoll(forced = null) {
     if ((!forced && !canPlayerRoll) || isAnimatingMove || isAnyRollAnimationRunning || isOpeningRollSequenceRunning || (isComputerTurn && !forced)) return;
+    if (!forced) {
+      // Fire when the human click successfully initiates a dice roll sequence.
+      trackRollDice();
+    }
     if (gamePhase === 'OPENING_ROLL') return void runOpeningRollSequence(forced);
     const d1 = forced?.[0] ?? random.rollDie1to6();
     const d2 = forced?.[1] ?? random.rollDie1to6();


### PR DESCRIPTION
### Motivation
- Centralize GA4 event calls so gameplay interactions can be tracked consistently while keeping pageview tracking intact and avoiding changes to game rules or behavior.
- Provide a safe, minimal analytics surface that no-ops when `window.gtag` is unavailable to avoid runtime errors in environments without GA.

### Description
- Added a small analytics module `src/analytics.js` exposing `trackEvent(eventName, params)` and typed wrappers `trackRollDice()`, `trackNewGame()`, `trackUndoMove()`, and `trackCheckerMove(params)`, and routed existing pageview logic through the same `gtag` guard helper.
- Instrumented human actions in `src/hooks/useGameController.js` only at commit points: `handleRoll` fires `roll_dice` for human-initiated rolls, `handleNewGame` fires `new_game` when starting a new game, `handleUndo` fires `undo_move` only when the `undoStack` actually pops, and `performMoveSequence` fires a single `checker_move` at commit time with parameters (`from_point`, `to_point`, `die_value`, `is_hit`, `is_bear_off`, `from_bar`, `remaining_dice_count`).
- Ensured single-event emission and human-only filtering by emitting `checker_move` inside the `setGame` commit updater when `stateAtMove.currentPlayer === PLAYER_A`, summing `dieUsed` values for chained moves to populate `die_value`, and adding inline comments near each instrumentation point explaining why the event is fired there.
- Files changed: `src/analytics.js` and `src/hooks/useGameController.js`.

### Testing
- Ran `npm run build` in the project environment to validate bundling and the change surface, and the build failed due to an existing unresolved `react-helmet-async` vendor import unrelated to these analytics changes (failure is environment/import related, not the instrumentation logic).
- No automated unit tests were added or modified as part of this change and existing game logic/tests were not altered by the instrumentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71eb8b740832eaff2072376f4f4a8)